### PR TITLE
Ubuntu fixup

### DIFF
--- a/core/alsp_src/builtins/blt_dvsh.pro
+++ b/core/alsp_src/builtins/blt_dvsh.pro
@@ -80,6 +80,8 @@ continue_prolog_loop(Status).
 	%% Cold startup in saved image, from TTY-command line start (i.e,unix):
 
 report_error(Error) :-
+        catch(report_error0(Error), _, (pbi_write(Error), pbi_nl)).
+report_error0(Error) :-
 	tk_new(I),
 	sprintf(atom(ErrorStr), '%t', [Error]),
 	tcl_call(I, [tk_messageBox,
@@ -119,7 +121,8 @@ start_alsdev0
 */
 	sys_env(OS, _, _),
 	join_path([ALSDIRPath,shared], Shared),
-	catch(tk_new(shl_tcli),Ball1,fail),
+	tk_new(shl_tcli),
+
 	tcl_call(shl_tcli, [wm,withdraw,'.'], _),
 	tcl_call(shl_tcli, [set,'ALSTCLPATH',Shared], _),
 	(OS = macos ->

--- a/core/alsp_src/unix/linux_makefile
+++ b/core/alsp_src/unix/linux_makefile
@@ -1,4 +1,4 @@
-CPPFLAGS += -DUNIX_LINUX -I /usr/include/libelf
+CPPFLAGS += -DUNIX_LINUX -I /usr/include/tcl -I /usr/include/libelf
 # On Linix the crypt() function may or may not be in the libc shared
 # object, depending on the particular linix setup.  We staticly link
 # it to avoid problems.

--- a/core/tcltk_interface/common/tcl_interface.c
+++ b/core/tcltk_interface/common/tcl_interface.c
@@ -53,7 +53,7 @@ char *version[2] = {
 #endif
 #endif
 
-static Tcl_ObjType *tcl_integer_type, *tcl_double_type, *tcl_list_type;
+static const Tcl_ObjType *tcl_integer_type, *tcl_double_type, *tcl_list_type;
 
 static AP_Obj TclToPrologObj(Tcl_Interp *interp, Tcl_Obj *tcl_obj, AP_World *w, AP_Obj *vars);
 static Tcl_Obj *PrologToTclObj(AP_World *w, AP_Obj prolog_obj, Tcl_Interp *interp);
@@ -168,13 +168,12 @@ PrologToTclResult(Tcl_Interp *interp, AP_World *w, AP_Result prolog_result)
 		break;
 	case AP_EXCEPTION: {
 		AP_Obj term_to_string, string;
-		AP_Result r;
 		term_to_string = AP_NewInitStructure(w,
 						AP_NewSymbolFromStr(w, "term_to_string"),
 						2,
 						AP_GetException(w),
 						AP_UNBOUND_OBJ);
-		r = AP_Call(w, tcltk_module, &term_to_string);
+		AP_Call(w, tcltk_module, &term_to_string); // ignore result
 		string = AP_GetArgument(w, term_to_string, 2);
 		
 		Tcl_ResetResult(interp);
@@ -374,8 +373,6 @@ Tcl_ALS_Prolog_ObjCmd(ClientData prolog_world, Tcl_Interp *interp, int objc, Tcl
 static int
 Tcl_DoOneEventCmd(ClientData data, Tcl_Interp *interp, int objc, Tcl_Obj *const *objv)
 {
-#pragma unused(data)
-
 	int index, result;
 	
 	enum {EVENT_WAIT, EVENT_DONT_WAIT};
@@ -755,7 +752,6 @@ static AP_Result tcl_delete(AP_World *w, AP_Obj interp_name)
 
 static AP_Result tcl_delete_all(AP_World *ignore)
 {
-#pragma unused(ignore)
 	Tcl_HashEntry *entry;
 	Tcl_HashSearch search;
 
@@ -773,8 +769,6 @@ static AP_Result tcl_delete_all(AP_World *ignore)
 
 static AP_Result tk_main_loop(AP_World *ignore)
 {
-#pragma unused(ignore)
-
 	Tk_MainLoop();
 	return AP_SUCCESS;
 }

--- a/core/tcltk_interface/common/tcl_interface.c
+++ b/core/tcltk_interface/common/tcl_interface.c
@@ -600,7 +600,9 @@ static AP_Result tk_new(AP_World *w, AP_Obj interp_name)
 	Tcl_Interp *interp;
 	
 	result = built_interp(w, &interp, &interp_name);
-	
+
+	// Similar to 2009 note above, this cause Tk_Init to fail (tk.tcl not found)
+#if 0
 	{
 		Tcl_DString path;
 		const char *elements[3];
@@ -616,6 +618,7 @@ static AP_Result tk_new(AP_World *w, AP_Obj interp_name)
 		Tcl_SetVar(interp, (char *)"tk_library", path.string, TCL_GLOBAL_ONLY);
 		Tcl_DStringFree(&path);
 	}
+#endif
 
 	if (result == AP_SUCCESS) {
 		int r = Tk_Init(interp);

--- a/unix/build_dist.sh
+++ b/unix/build_dist.sh
@@ -49,7 +49,7 @@ then
 fi
 
 # Use -L to force dereferences of symbolic links
-cp -prL "$BIN/alsdir" "$DISTDIR"
+cp -pRL "$BIN/alsdir" "$DISTDIR"
 rm -f "$DISTDIR/alsdir/builtins/blt_shl.pro"
 rm -f "$DISTDIR/alsdir/builtins/blt_dvsh.pro"
 rm -f "$DISTDIR/alsdir/builtins/ra_basis.pro"

--- a/unix/build_dist.sh
+++ b/unix/build_dist.sh
@@ -47,7 +47,9 @@ if test -f "$BIN/$EXE.pst"
 then
     cp -pr "$BIN/$EXE.pst" "$DISTDIR/$EXET.pst"
 fi
-cp -pr "$BIN/alsdir" "$DISTDIR"
+
+# Use -L to force dereferences of symbolic links
+cp -prL "$BIN/alsdir" "$DISTDIR"
 rm -f "$DISTDIR/alsdir/builtins/blt_shl.pro"
 rm -f "$DISTDIR/alsdir/builtins/blt_dvsh.pro"
 rm -f "$DISTDIR/alsdir/builtins/ra_basis.pro"


### PR DESCRIPTION
This pull fixes things up so that alsdev runs normally on Ubuntu (32-bit). I've tested the branch on Mac to ensure there are no regression. Please review full diff and/or individual commits, and test the branch -- if you concur that all is well, then merge it to master.

Hardest part was tracking down the failure caused by `catch(tk_new(shl_tcli),Ball1,fail)`. It converts an exception into a failure, resulting in tricky to debug infinite retries. If there was a list of Prolog anti-patterns, I'd vote to include `catch(do_something, _, fail)` on it!