### PR TITLE
Win32 fixup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,13 @@
 *.obp
 *.d
 *.o
-
+*.a
+*.dll
+*.exe
+*.pst
+*.tgz
+core/win32/alsdir
+core/win32/lib
+core/unix/*/alsdir
+core/unix/*/lib
+foreign_sdk/*/ALS_Prolog_Foreign_SDK

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ where darwin is the Mac OS X flavor of linux, and <flavor> is possibly some othe
 
 **Windows:**
 
+Build Tools:
+- ActiveTcl 8.6 (32-bit)
+- Cygwin 32-bit, with packages:
+  - Devel
+  - Tcl-Tk
+  - X11
+  - Archive/Zip
+
+
 Locate yourself in the toplevel 'win32' directory in the tree, and execute 'make'.  When the build completes, you will find a folder  
 
 	win32/als-prolog	

--- a/core/als_dev/alsdev/getDirectory/getDirectory.c
+++ b/core/als_dev/alsdev/getDirectory/getDirectory.c
@@ -14,11 +14,10 @@
 static int
 getDirectory_ObjCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const *objv)
 {
-#pragma unused(clientData)
 
 	enum {INITIAL_DIR, PARENT, PROMPT};
-	char *options[] = {"-initialdir", "-parent", "-prompt", NULL};
-	char *ophelp[] = {"a directory path", "a window name", "a prompt string"};
+	const char *options[] = {"-initialdir", "-parent", "-prompt", NULL};
+	const char *ophelp[] = {"a directory path", "a window name", "a prompt string"};
 	int index, i, result;
 	Tcl_DString initdir;
 	Tk_Window parent = NULL;
@@ -64,9 +63,7 @@ exit:
 }
 
 
-#pragma export on
 __declspec(dllexport) int  Getdirectory_Init(Tcl_Interp *interp);
-#pragma export reset
 __declspec(dllexport) int Getdirectory_Init(Tcl_Interp *interp)
 {
 	if (!Tcl_PkgRequire(interp, "Tcl", TCL_VERSION, 0)

--- a/core/als_dev/alsdev/getDirectory/win32_getDirectory.c
+++ b/core/als_dev/alsdev/getDirectory/win32_getDirectory.c
@@ -1,4 +1,5 @@
 #include "getDirectory.h"
+#include <windows.h>
 #include <shlobj.h>
 
 /* Tk_GetHWND proto is from tkWin.h */

--- a/core/als_dev/alsdev/getDirectory/win32_getDirectory.c
+++ b/core/als_dev/alsdev/getDirectory/win32_getDirectory.c
@@ -7,8 +7,6 @@ HWND Tk_GetHWND(Window window);
 int GetDirectory(Tcl_Interp *interp, Tcl_DString *initdir,
 	Tk_Window parent, const char *prompt)
 {
-#pragma unused(initdir)
-
 	BROWSEINFO bi;
 	char name[MAX_PATH];
 	LPITEMIDLIST idlist;

--- a/core/als_dev/alsdev/getFiles/getFiles.c
+++ b/core/als_dev/alsdev/getFiles/getFiles.c
@@ -14,11 +14,10 @@
 static int
 getFiles_ObjCmd(ClientData clientData, Tcl_Interp *interp, int objc, Tcl_Obj *const *objv)
 {
-#pragma unused(clientData)
 
 	enum {INITIAL_DIR, PARENT, PROMPT};
-	char *options[] = {"-initialdir", "-parent", "-prompt", NULL};
-	char *ophelp[] = {"a directory path", "a window name", "a prompt string"};
+	const char *options[] = {"-initialdir", "-parent", "-prompt", NULL};
+	const char *ophelp[] = {"a directory path", "a window name", "a prompt string"};
 	int index, i, result;
 	Tcl_DString initdir;
 	Tk_Window parent = NULL;

--- a/core/als_dev/alsdev/win32_alsdev.c
+++ b/core/als_dev/alsdev/win32_alsdev.c
@@ -239,10 +239,14 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 			panic("Couldn't get full path");
 		
 		*dir_end = 0;
-		sprintf(env, "TCL_LIBRARY=%slib\\tcl" TCL_VERSION "\\", dir);
-				
+
+		sprintf(env, "TCL_LIBRARY=%slib\\tcl" TCL_VERSION, dir);
 		if (Tcl_PutEnv(env) != TCL_OK)
 			panic("Couldn't set TCL_LIBRARY");
+
+		sprintf(env, "TK_LIBRARY=%slib\\tk" TCL_VERSION, dir);
+		if (Tcl_PutEnv(env) != TCL_OK)
+			panic("Couldn't set TK_LIBRARY");
 	}
 	
 	/* Make the OpenDocument package available to Tcl */

--- a/core/als_dev/alsdev/win32_alsdev.c
+++ b/core/als_dev/alsdev/win32_alsdev.c
@@ -16,7 +16,7 @@
 
 extern void tcl_interface_init(void);
 
-extern void panic(const char *);
+//extern void panic(const char *);
 
 static char *simple_write(AP_World *w, AP_Obj obj, char *s)
 {
@@ -208,6 +208,7 @@ void setup_alsdev_demo(void);
 void shutdown_alsdev_demo(void);
 #endif
 
+    	extern long ss_image_offset(const char *image_name);
 
 int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
 {
@@ -284,8 +285,7 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	   Since blt_dvsh is part of the state, reconsulting
 	   does not work correctly. */
 {
-	extern char executable_path[1024];
-	extern long ss_image_offset(const char *image_name);
+  //	extern char executable_path[1024];
 
 	if (!ss_image_offset(executable_path)) {
 #if 0

--- a/core/als_dev/alsdev/win32_alsdev.c
+++ b/core/als_dev/alsdev/win32_alsdev.c
@@ -217,7 +217,9 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	PI_system_setup setup;
 	AP_Obj term;
 	AP_World *w = NULL;
-
+	
+	Tcl_FindExecutable(NULL);
+	
 	/* Allow only one instance to run and have it process the command line. */
 	mutex = CreateMutex(NULL, FALSE, "ALS Prolog Environment Mutex");
 	if (!mutex) return FALSE;

--- a/core/alsp_src/generic/fpbasis.c
+++ b/core/alsp_src/generic/fpbasis.c
@@ -7,11 +7,8 @@
  *===========================================================================*/
 #include "defs.h"
 #include "fpbasis.h"
-#ifdef MacOS
-#include <fp.h>
-#elif defined(MSWin32)
+
 #include <math.h>
-#endif
 
 int is_ieee_nan PARAMS( (double) );
 int is_ieee_inf PARAMS( (double) );

--- a/core/alsp_src/generic/fpbasis.h
+++ b/core/alsp_src/generic/fpbasis.h
@@ -6,11 +6,6 @@
  |
  *===========================================================================*/
 
-#ifndef MacOS
-extern int isnan PARAMS( (double) );
-extern int isinf PARAMS( (double) );
-extern int finite PARAMS( (double) );
-#endif
 
 #ifdef HAVE_IEEE_FP
 #include <ieeefp.h>

--- a/core/alsp_src/generic/fswin32.h
+++ b/core/alsp_src/generic/fswin32.h
@@ -63,8 +63,7 @@ int als_system(const char * command);
 #include <unistd.h>
 
 #define lstat stat
-pid_t _getpid(void);
-#define getpid _getpid
+
 #else
 
 #include <sys/stat.h>

--- a/core/alsp_src/generic/gnu_makefile
+++ b/core/alsp_src/generic/gnu_makefile
@@ -153,7 +153,7 @@ ALSDEV_LIBS = -litcl3.0 -litk3.0 -ltcl8.0 -ltk8.0
 
 alsdev_b : libalspro.a $(ALSDEV_OBJECTS) $(MAKEFS)
 # $(CC) $(CFLAGS) -o alsdev_b  $(ALSDEV_OBJECTS) libalspro.a -L$(ALS_BUILD_SUPPORT)/$(SUBOS)/lib -litcl3.0 -litk3.0 -ltcl8.0 -ltk8.0 -L/usr/lib/X11 -lX11 $(LIBS)
-	$(CC) $(CFLAGS) -o alsdev_b  $(ALSDEV_OBJECTS) libalspro.a $(ALS_BUILD_SUPPORT_LIBDIR) -ltcl -ltk $(LIBS)
+	$(CC) $(CFLAGS) -o alsdev_b  $(ALSDEV_OBJECTS) libalspro.a $(ALS_BUILD_SUPPORT_LIBDIR) -ltcl$(TCLVER) -ltk$(TCLVER) $(LIBS)
 
 
 alsdev :  alsdev_b alsdir alsdir/images alsdir/shared $(BUILTINS) $(ALSDEVFILES) $(ALSDEVLIBPS) lib $(MAKEFS)

--- a/core/alsp_src/win32/gcc_makefile
+++ b/core/alsp_src/win32/gcc_makefile
@@ -14,5 +14,7 @@ CC=i686-w64-mingw32-gcc -m32
 
 # -Wno-trigraphs added to avoid warnings for Apple '????'-style constants.
 
-CFLAGS += -O -MMD -Wall -Werror -Wmissing-prototypes -Wwrite-strings \
+# Added -Wno-error=pointer-sign to avoid blocking errors in socket code
+
+CFLAGS += -O -MMD -Wall -Werror -Wno-error=pointer-sign -Wmissing-prototypes -Wwrite-strings \
 		 -Wnested-externs -Wpointer-arith -Wno-trigraphs

--- a/core/alsp_src/win32/gcc_makefile
+++ b/core/alsp_src/win32/gcc_makefile
@@ -1,5 +1,5 @@
 # For the moment, generate 32-bit code. ALS Prolog is not yet 64-bit compatible.
-CC=i686-pc-mingw32-gcc -m32
+CC=i686-w64-mingw32-gcc -m32
 # Unused warning options and why:
 
 #-Wshadow - We use shadow variables - should be fixed someday.

--- a/core/alsp_src/win32/mswin32_config.h
+++ b/core/alsp_src/win32/mswin32_config.h
@@ -28,10 +28,9 @@
 
 #define HAVE_TIME		1
 
-// Temporarily disable Sockets for MinGW evaluation (Fix before master merge!)
-//#define HAVE_SOCKET		1
-//#define BERKELEY_SOCKETS	1
-//#define HAVE_SELECT		1
+#define HAVE_SOCKET		1
+#define BERKELEY_SOCKETS	1
+#define HAVE_SELECT		1
 #define MISSING_UNIX_DOMAIN_SOCKETS 1
 
 #define APP_PRINTF_CALLBACK	1
@@ -49,4 +48,5 @@ extern __inline__ void* GetCurrentFiber(void);
 extern __inline__ void* GetFiberData(void);
 #endif
 
+#include <winsock2.h>
 #include <windows.h>

--- a/core/alsp_src/win32/win32_makefile
+++ b/core/alsp_src/win32/win32_makefile
@@ -16,7 +16,7 @@ ALS_BUILD_SUPPORT_INCLUDES = -isystem $(ALS_BUILD_SUPPORT)/include/tcl8.5
 
 ALS_BUILD_SUPPORT_LIBDIR = -L $(ALS_BUILD_SUPPORT)/lib
 
-ALSDEV_OS_SOURCE = win32_alsdev.c alsdev_demo.c getDirectory.c win32_getDirectory.c getFiles.c win32_getFiles.c
+ALSDEV_OS_SOURCE = win32_alsdev.c getDirectory.c win32_getDirectory.c getFiles.c win32_getFiles.c
 
 ALS_STUB_SOURCE = win32_alsdev.c tcl_interface.c getDirectory.c win32_getDirectory.c getFiles.c win32_getFiles.c
 ALS_STUB_OBJECTS = $(ALS_STUB_SOURCE:.c=.o)

--- a/core/alsp_src/win32/win32_makefile
+++ b/core/alsp_src/win32/win32_makefile
@@ -16,6 +16,9 @@ ALS_BUILD_SUPPORT_INCLUDES = -isystem $(ALS_BUILD_SUPPORT)/include/tcl8.5
 
 ALS_BUILD_SUPPORT_LIBDIR = -L $(ALS_BUILD_SUPPORT)/lib
 
+# Set path to allow access to Tcl/Tk DLLs
+export PATH := $(ALS_BUILD_SUPPORT)/bin:$(PATH)
+
 ALSDEV_OS_SOURCE = win32_alsdev.c getDirectory.c win32_getDirectory.c getFiles.c win32_getFiles.c
 
 ALS_STUB_SOURCE = win32_alsdev.c tcl_interface.c getDirectory.c win32_getDirectory.c getFiles.c win32_getFiles.c

--- a/core/alsp_src/win32/win32_makefile
+++ b/core/alsp_src/win32/win32_makefile
@@ -7,12 +7,13 @@ OS_SL_EXT = dll
 OS_SL_LINK = $(CC) -shared
 LIBS = -lwsock32 -lcomdlg32
 SL_LINK_LIBS = $(LIBS)
-TCLVER=86
+TCLVER=85
 
 VPATH += :$(ALSDEVDIR)/getFiles:$(ALSDEVDIR)/getDirectory
 
-ALS_BUILD_SUPPORT = '/cygdrive/c/Tcl'
-ALS_BUILD_SUPPORT_INCLUDES = -isystem $(ALS_BUILD_SUPPORT)/include -isystem $(ALS_BUILD_SUPPORT)/include/X11
+ALS_BUILD_SUPPORT = /usr/i686-w64-mingw32/sys-root/mingw/
+ALS_BUILD_SUPPORT_INCLUDES = -isystem $(ALS_BUILD_SUPPORT)/include/tcl8.5
+
 ALS_BUILD_SUPPORT_LIBDIR = -L $(ALS_BUILD_SUPPORT)/lib
 
 ALSDEV_OS_SOURCE = win32_alsdev.c alsdev_demo.c getDirectory.c win32_getDirectory.c getFiles.c win32_getFiles.c

--- a/core/alsp_src/win32/win32_makefile
+++ b/core/alsp_src/win32/win32_makefile
@@ -5,16 +5,17 @@ OS_AR = ar rusc
 OS_RANLIB = true
 OS_SL_EXT = dll
 OS_SL_LINK = $(CC) -shared
-LIBS = -lwsock32
+LIBS = -lwsock32 -lcomdlg32
 SL_LINK_LIBS = $(LIBS)
+TCLVER=86
 
 VPATH += :$(ALSDEVDIR)/getFiles:$(ALSDEVDIR)/getDirectory
 
-ALS_BUILD_SUPPORT = '/cygdrive/c/Program Files/Metrowerks/CodeWarrior/ALS Build Support'
-ALS_BUILD_SUPPORT_INCLUDES = -isystem $(ALS_BUILD_SUPPORT)/'Tcl-Tk Support/include' -isystem $(ALS_BUILD_SUPPORT)/'Tcl-Tk Support/include/X11'
-ALS_BUILS_SUPPORT_LIBS = 
+ALS_BUILD_SUPPORT = '/cygdrive/c/Tcl'
+ALS_BUILD_SUPPORT_INCLUDES = -isystem $(ALS_BUILD_SUPPORT)/include -isystem $(ALS_BUILD_SUPPORT)/include/X11
+ALS_BUILD_SUPPORT_LIBDIR = -L $(ALS_BUILD_SUPPORT)/lib
 
-ALSDEV_OS_SOURCE = win32_alsdev.c tcl_interface.c alsdev_demo.c getDirectory.c win32_getDirectory.c getFiles.c win32_getFiles.c
+ALSDEV_OS_SOURCE = win32_alsdev.c alsdev_demo.c getDirectory.c win32_getDirectory.c getFiles.c win32_getFiles.c
 
 ALS_STUB_SOURCE = win32_alsdev.c tcl_interface.c getDirectory.c win32_getDirectory.c getFiles.c win32_getFiles.c
 ALS_STUB_OBJECTS = $(ALS_STUB_SOURCE:.c=.o)
@@ -36,7 +37,7 @@ alsdir/shared : $(MAKEFS)
 	mkdir -p alsdir/shared
 	rm -f alsdir/shared/*.pro alsdir/shared/*.psl alsdir/shared/*.tcl
 	cd alsdir/shared ; cp ../../$(CORE)/als_dev/alsdev/*.tcl .
-				 
+
 alsdir/images : $(CORE)/als_dev/alsdev $(MAKEFS)
 	mkdir -p alsdir/images
 	rm -f alsdir/images/*.*

--- a/foreign_sdk/win32/make.bat
+++ b/foreign_sdk/win32/make.bat
@@ -1,9 +1,9 @@
-rmdir ALS_Prolog_Foreign_SDK /S
+rmdir ALS_Prolog_Foreign_SDK /S /Q
 
 mkdir "ALS_Prolog_Foreign_SDK"
 cd "ALS_Prolog_Foreign_SDK"
 mkdir ALS_Prolog_Support
-copy ..\..\..\core\win32\alspro.lib ALS_Prolog_Support
+copy ..\..\..\core\win32\libalspro.a ALS_Prolog_Support
 copy ..\..\..\core\alsp_src\generic\alspi.h ALS_Prolog_Support
 copy ..\..\..\core\alsp_src\generic\alspi_slib.h ALS_Prolog_Support
 copy ..\..\..\core\alsp_src\generic\alspi_slib.c ALS_Prolog_Support

--- a/win32/Makefile
+++ b/win32/Makefile
@@ -1,15 +1,24 @@
 all: standard 
 
 core:
-	cd ../core/win32 ; ./build.bat
+	$(MAKE) -C ../core/win32
 	cd ../foreign_sdk/win32 ; ./make.bat
 
 odbc:
 	cd ../extensions/odbc/i386_mswin32 ; ./build.bat
-	
+
 python:
 	cd ../extensions/python/i386_mswin32 ; ./build.bat
-	
+
 #standard: core odbc python
-standard: core odbc 
+standard: core
 	./build_dist.sh standard
+
+all: standard
+
+test: core
+	$(MAKE) -C ../core/win32 test
+
+distclean:
+	$(MAKE) -C ../core/win32 distclean
+	sh superclean.sh

--- a/win32/build_dist.sh
+++ b/win32/build_dist.sh
@@ -15,6 +15,8 @@ esac
 
 ALS_PROLOG=..
 BIN=$ALS_PROLOG/core/$ARCH
+ALS_BUILD_SUPPORT=/usr/i686-w64-mingw32/sys-root/mingw/
+
 LIB=$ALS_PROLOG/core/alsp_src/library
 EXAMPLES=$ALS_PROLOG/examples
 MAN=$ALS_PROLOG/manual
@@ -61,6 +63,13 @@ rm -f "$DISTDIR/alsdir/builtins/blt_dvsh.pro"
 rm -f "$DISTDIR/alsdir/builtins/ra_basis.pro"
 rm -f "$DISTDIR/alsdir/builtins/int_cstr.pro"
 cp -pr "$BIN/lib" "$DISTDIR"
+
+# MinGW64 libs
+cp -p "$ALS_BUILD_SUPPORT"/bin/tcl85.dll "$DISTDIR"
+cp -p "$ALS_BUILD_SUPPORT"/bin/tk85.dll "$DISTDIR"
+cp -p "$ALS_BUILD_SUPPORT"/bin/libgcc_s_sjlj-1.dll "$DISTDIR"
+cp -pr "$ALS_BUILD_SUPPORT"/lib/tcl8.5 "$DISTDIR"/lib
+cp -pr "$ALS_BUILD_SUPPORT"/lib/tk8.5 "$DISTDIR"/lib
 
 mkdir "$DISTDIR/examples"
 for E in $EXAMPLE_SET ; do

--- a/win32/build_dist.sh
+++ b/win32/build_dist.sh
@@ -1,21 +1,27 @@
-:
 #!/bin/sh
 
-set -o errexit -o nounset
+set -eu
+
+case `uname -rs` in
+    "SunOS 4"*)	ARCH=sunos   ; SOEXT=so    ;;
+    "SunOS 5"*)	ARCH=solaris ; SOEXT=so    ;;
+    Linux*) 	ARCH=linux   ; SOEXT=so    ;;
+    "HP-UX"*)	ARCH=hpux    ; SOEXT=sl    ;;
+    "IRIX"*)	ARCH=irix    ; SOEXT=so    ;;
+    "CYGWIN"*)  ARCH=win32  ; SOEXT=dll   ;;
+    "Darwin"*)	ARCH=darwin  ; SOEXT=dylib ;;
+    *) 		echo "Unknown machine type..."; exit 1 ;;
+esac
 
 ALS_PROLOG=..
-BIN=$ALS_PROLOG/core/win32
+BIN=$ALS_PROLOG/core/$ARCH
 LIB=$ALS_PROLOG/core/alsp_src/library
-BUILTINS=$ALS_PROLOG/core/alsp_src/builtins
 EXAMPLES=$ALS_PROLOG/examples
 MAN=$ALS_PROLOG/manual
-EXTRAS=$ALS_PROLOG/../als_addl_software
-ODBC=$ALS_PROLOG/extensions/odbc
-PYTHON=$ALS_PROLOG/extensions/python
 
 if test $# -ne 1
 then
-    echo "Usage: $0 [standard | demo]" 1>&2
+    echo "Usage: $0 [standard]" 1>&2
     exit 2
 fi
 
@@ -23,28 +29,38 @@ EDITION=$1
 
 case $EDITION in
 standard)
-DISTDIR="ALS Prolog" ;
-EXE="ALS Prolog.exe" ;
-EXET="ALS Prolog.exe" ;
-EXAMPLE_SET="als pxs more objectpro visual Prolog1000 Chat80" ;
-MANUAL=als_man.pdf ; 
-MANUALNAME="ALS Prolog Manual.pdf" ;
+DISTNAME=als-prolog
+DISTDIR=$ARCH/$DISTNAME ;
+EXE=alsdev ;
+EXET=alsdev ;
+EXAMPLE_SET="als pxs more objectpro visual chat80 Prolog1000" ;
+MANUAL=als_man.pdf ; # standard manual is missing.
+REFMANUAL=ref_man.pdf ; 
+MANUALNAME=als-prolog-manual.pdf ;
+REFMANUALNAME=als-ref-manual.pdf ;
 HELP="alshelp" ;
 ;;
 esac
 
 rm -rf "$DISTDIR"
-mkdir "$DISTDIR"
+mkdir -p "$DISTDIR"
 
 cp -pr "$BIN/$EXE" "$DISTDIR/$EXET"
-cp -pr "$BIN/msvcrt.dll" "$DISTDIR"
-cp -pr "$BIN/tcl80.dll" "$DISTDIR"
-cp -pr "$BIN/tk80.dll" "$DISTDIR"
-cp -pr "$BIN/tclpip80.dll" "$DISTDIR"
-cp -pr "$BIN/alsdir" "$DISTDIR"
+if test -f "$BIN/$EXE.pst"
+then
+    cp -pr "$BIN/$EXE.pst" "$DISTDIR/$EXET.pst"
+elif test -f "$BIN/$EXE.exe.pst"
+then
+    cp -pr "$BIN/$EXE.exe.pst" "$DISTDIR"
+fi
+
+# Use -L to force dereferences of symbolic links
+cp -pRL "$BIN/alsdir" "$DISTDIR"
+rm -f "$DISTDIR/alsdir/builtins/blt_shl.pro"
+rm -f "$DISTDIR/alsdir/builtins/blt_dvsh.pro"
+rm -f "$DISTDIR/alsdir/builtins/ra_basis.pro"
+rm -f "$DISTDIR/alsdir/builtins/int_cstr.pro"
 cp -pr "$BIN/lib" "$DISTDIR"
-cp -pr "$BIN/lib/itcl3.0/itcl30.dll" "$DISTDIR"
-cp -pr "$BIN/lib/itk3.0/itk30.dll" "$DISTDIR"
 
 mkdir "$DISTDIR/examples"
 for E in $EXAMPLE_SET ; do
@@ -52,77 +68,38 @@ for E in $EXAMPLE_SET ; do
 done
 
 cp "$ALS_PROLOG/LICENSE.txt" "$DISTDIR/LICENSE.txt"
-cp -p $MAN/welcome_standard.txt" "$DISTDIR/README.txt"
+cp -p "$MAN/welcome_standard.txt" "$DISTDIR/README.txt"
 cp -p $MAN/$MANUAL "$DISTDIR/$MANUALNAME"
-mkdir "$DISTDIR/help"
-cp -pr $MAN/$HELP/* "$DISTDIR/help"
-cp -p $MAN/als_help.htm "$DISTDIR/als_help.htm"
+cp -p $MAN/$REFMANUAL "$DISTDIR/$REFMANUALNAME"
+mkdir "$DISTDIR/alshelp"
+cp -pr $MAN/$HELP/* "$DISTDIR/alshelp"
+cp -p $MAN/als_help.html "$DISTDIR/als_help.html"
+cp -p $MAN/alshelp.css "$DISTDIR/alshelp.css"
+cp -p $MAN/package_nav.html "$DISTDIR/package_nav.html"
 
-mkdir "$DISTDIR/alsdir/builtins"
-cp -p $BUILTINS/*.pro "$DISTDIR/alsdir/builtins"
 
-mkdir "$DISTDIR/alsdir/library"
-cp -p $LIB/*.pro "$DISTDIR/alsdir/library"
-cp -p $LIB/*.alb "$DISTDIR/alsdir/library"
-
-rm -f "$DISTDIR/alsdir/builtins/blt_shl.pro"
-rm -f "$DISTDIR/alsdir/builtins/blt_dvsh.pro"
-rm -f "$DISTDIR/alsdir/builtins/ra_basis.pro"
-rm -f "$DISTDIR/alsdir/builtins/int_cstr.pro"
-
-EXTRATCL=`ls $EXTRAS/common/tcltk`
-for XX in $EXTRATCL 
-do
-cp -pr "$EXTRAS/common/tcltk/$XX" "$DISTDIR/lib"
-done
-IWIDGETS=`ls $EXTRAS/common/iwidgets`
-for XX in $IWIDGETS 
-do
-cp -pr "$EXTRAS/common/iwidgets/$XX" "$DISTDIR/lib/iwidgets3.0/scripts"
-done
+#mkdir "$DISTDIR/alsdir/library"
+#cp -p $LIB/*.pro "$DISTDIR/alsdir/library"
+#cp -p $LIB/*.alb "$DISTDIR/alsdir/library"
 
 if test $EDITION = standard
 then
 	cp -pr "$ALS_PROLOG/foreign_sdk/win32/ALS_Prolog_Foreign_SDK" "$DISTDIR"
-	cp -pr "$BIN/alspro.exe" "$DISTDIR"
-	cp -pr "$BIN/alspro.dll" "$DISTDIR"
-	cp -pr "$BIN/Generic ALS App Stub.exe" "$DISTDIR"
+	cp -pr "$BIN/alspro" "$DISTDIR"
+	if test -f "$BIN/alspro.pst"
+	then
+	    cp -pr "$BIN/alspro.pst" "$DISTDIR"
+	elif test -f "$BIN/alspro.exe.pst"
+	then
+	    cp -pr "$BIN/alspro.exe.pst" "$DISTDIR"
+
+	fi
+	cp -pr "$BIN/libalspro.a" "$DISTDIR"
+	cp -pr "$BIN/libalspro.$SOEXT" "$DISTDIR"
 fi
 
-if test $EDITION = demo
-then
-	cp -pr "$ALS_PROLOG/foreign_sdk/win32/ALS_Prolog_Foreign_SDK" "$DISTDIR"
-	cp -pr "$BIN/alspro_demo.exe" "$DISTDIR/alspro.exe"
-	cp -pr "$BIN/alspro.dll" "$DISTDIR"
-	cp -pr "$BIN/Generic ALS App Stub.exe" "$DISTDIR"
-fi
-
-if test $EDITION = standard -o $EDITION = demo
-then
-	mkdir "$DISTDIR/odbc"
-	cp -pr "$ODBC/common/odbc.pro" "$DISTDIR/odbc"
-	cp -pr "$ODBC/examples/odbc_samples.pro" "$DISTDIR/odbc"
-	cp -pr "$ODBC/examples/sql_shell.pro" "$DISTDIR/odbc"
-	cp -pr "$ODBC/examples/sql_shell.ppj" "$DISTDIR/odbc"
-	cp -pr "$ODBC/examples/economics.mdb" "$DISTDIR/odbc"
-	cp -pr "$ODBC/src/meta_odbc.pro" "$DISTDIR/odbc"
-	cp -pr "$ODBC/src/prolog_odbc.pro" "$DISTDIR/odbc"
-	cp -pr "$ODBC/i386_mswin32/odbcintf.psl" "$DISTDIR/alsdir/shared"
-	cp -pr "$ODBC/doc/odbc.pdf" "$DISTDIR/odbc"
-	
-	cp -pr "$ALS_PROLOG/core/tcltk_interface/mswin32/tclintf.psl" "$DISTDIR/alsdir/shared"
-	cp -pr "$ALS_PROLOG/core/tcltk_interface/common/tcltk.pro" "$DISTDIR/alsdir/shared"
-	cp -pr "$ALS_PROLOG/core/tcltk_interface/common/tcltk_util.pro" "$DISTDIR/alsdir/shared"
-
-	mkdir "$DISTDIR/python"
-
-#	cp -pr "$PYTHON/i386_mswin32/python.psl" "$DISTDIR/alsdir/shared"
-#	cp -pr "$PYTHON/common/als_python_guide.html" "$DISTDIR/python"
-#	cp -pr "$PYTHON/common/py_test.pro" "$DISTDIR/python"
-#	cp -pr "$PYTHON/common/test_util.py" "$DISTDIR/python"
-
-fi
+tar -C $ARCH -czf $DISTNAME-$ARCH.tgz $DISTNAME
 
 
-echo "Build directory complete."
-echo "Please add the directory to the installer script and create installer."
+
+

--- a/win32/build_dist.sh
+++ b/win32/build_dist.sh
@@ -98,8 +98,7 @@ then
 	cp -pr "$BIN/libalspro.$SOEXT" "$DISTDIR"
 fi
 
-tar -C $ARCH -czf $DISTNAME-$ARCH.tgz $DISTNAME
-
-
-
-
+rm -f $DISTNAME-$ARCH.zip
+pushd $ARCH
+zip -r ../$DISTNAME-$ARCH.zip $DISTNAME
+popd


### PR DESCRIPTION
Fixes #16 so alsdev can be built and packaged for windows using MinGW-64.