### PR TITLE
Iss45

### DIFF
--- a/core/als_dev/alsdev/alsdev.tcl
+++ b/core/als_dev/alsdev/alsdev.tcl
@@ -680,6 +680,7 @@ proc debugwin.consult { Window } {
 }
 
 proc consult_file {} {
+puts ">>consult_file"
 	set file [tk_getOpenFile \
 		-defaultextension pro \
 		-title "Consult File" \
@@ -687,6 +688,8 @@ proc consult_file {} {
 		-filetypes {{"Prolog Files" {.pro .pl } } {{All Files} {*} } } ]
 	if {$file == ""} then { return }
 	prolog call alsdev do_reconsult -atom $file
+puts ">>EXIT consult_file"
+refresh_spy_preds_if_showing
 	return true
 }
 
@@ -1118,6 +1121,15 @@ proc refresh_spy_win {} {
 	refresh_mods_list
 	set MF [get_module_focus]
 	if  {$MF != ""} then { refresh_preds_list $MF }
+}
+
+proc refresh_spy_preds_if_showing {} {
+	global array proenv
+puts "ENTER refresh_spy_preds_if_showing"
+
+	if {[winfo exists .pred_info] == 1} then { 
+		refresh_spy_win
+	}
 }
 
 proc move_to_spying_list {} {

--- a/core/als_dev/alsdev/alsdev.tcl
+++ b/core/als_dev/alsdev/alsdev.tcl
@@ -680,7 +680,6 @@ proc debugwin.consult { Window } {
 }
 
 proc consult_file {} {
-puts ">>consult_file"
 	set file [tk_getOpenFile \
 		-defaultextension pro \
 		-title "Consult File" \
@@ -688,8 +687,7 @@ puts ">>consult_file"
 		-filetypes {{"Prolog Files" {.pro .pl } } {{All Files} {*} } } ]
 	if {$file == ""} then { return }
 	prolog call alsdev do_reconsult -atom $file
-puts ">>EXIT consult_file"
-refresh_spy_preds_if_showing
+	refresh_spy_preds_if_showing
 	return true
 }
 
@@ -1125,7 +1123,6 @@ proc refresh_spy_win {} {
 
 proc refresh_spy_preds_if_showing {} {
 	global array proenv
-puts "ENTER refresh_spy_preds_if_showing"
 
 	if {[winfo exists .pred_info] == 1} then { 
 		refresh_spy_win

--- a/core/als_dev/alsdev/debugwin.tcl
+++ b/core/als_dev/alsdev/debugwin.tcl
@@ -487,12 +487,9 @@ proc vTclWindow.pred_info {base} {
     button $base.buttons.wamlisting \
         -padx 11 -pady 2 -text {WAM Asm} \
 		-command carry_out_listasm -state disabled
-    button $base.buttons.refreshpreds \
-        -padx 1 -pady 2 -text {Refresh Preds} \
-		-command refresh_the_preds
-    button $base.buttons.refreshmods \
-        -padx 1 -pady 2 -text {Refresh Mods} \
-		-command refresh_mods_list
+    button $base.buttons.refreshspywin \
+        -padx 11 -pady 2 -text {Refresh} \
+		-command refresh_spy_win
 
     frame $base.spying \
         -borderwidth 1 -relief sunken  
@@ -599,9 +596,7 @@ proc vTclWindow.pred_info {base} {
 		 -anchor center -expand 0 -fill none -side top -pady 6
     pack $base.buttons.wamlisting \
 		 -anchor center -expand 0 -fill none -side top -pady 6
-    pack $base.buttons.refreshpreds \
-		 -anchor center -expand 0 -fill none -side bottom -pady 6
-    pack $base.buttons.refreshmods \
+    pack $base.buttons.refreshspywin \
 		 -anchor center -expand 0 -fill none -side bottom -pady 6
 
     grid $base.spying \

--- a/core/alsp_src/builtins/blt_cslt.pro
+++ b/core/alsp_src/builtins/blt_cslt.pro
@@ -189,8 +189,8 @@ consult(What, Options)
 	:-
 	consult_global_options(Options, COpts),
 	consult_files(What, COpts),
-    	builtins:get_primary_manager(ALSMgr),
-        send(ALSMgr, refresh_wins).
+	builtins:get_primary_manager(ALSMgr),
+	send(ALSMgr, refresh_wins).
 
 consult_files([], _) 
 	:-!.
@@ -453,7 +453,6 @@ cslt_info_recon(FileDesc, Nature, Nature, Recon, Recon, FileDesc).
 	%% MESSAGE LEVEL OF CONSULT 
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-
 /*-------------------------------------------------------------*
  | do_consult/2
  | do_consult(BaseFile, FileConsultOpts)
@@ -478,7 +477,6 @@ do_consult(BaseFile, FCOpts)
 			consult_except_resp(Ball,FCOpts,FileMgr,FinalMsg)
 	     ),
 	send(ALSMgr, set_value(cslt_ctxt, PrevCntxts)),
-%send(ALSMgr, refresh_wins),
 	record_consult(BaseFile, FCOpts, Ball, FileMgr, ALSMgr),
 	!,
 	consult_msg(FinalMsg, FCOpts).

--- a/core/alsp_src/builtins/blt_cslt.pro
+++ b/core/alsp_src/builtins/blt_cslt.pro
@@ -188,7 +188,8 @@ reconsult(What)
 consult(What, Options)
 	:-
 	consult_global_options(Options, COpts),
-	consult_files(What, COpts).
+	consult_files(What, COpts),
+	builtins:refresh_spy_preds_if_showing.
 
 consult_files([], _) 
 	:-!.
@@ -450,6 +451,18 @@ cslt_info_recon(FileDesc, Nature, Nature, Recon, Recon, FileDesc).
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	%% MESSAGE LEVEL OF CONSULT 
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+/*-------------------------------------------------------------*
+ | If in alsdev, check to refresh spy window (pred_info)
+ | if needed.
+ *-------------------------------------------------------------*/ 
+refresh_spy_preds_if_showing
+	:-
+	builtins:clause(alsdev_running,_),
+	!,
+ 	tcl_call(shl_tcli, [refresh_spy_preds_if_showing], _).
+refresh_spy_preds_if_showing.
+
+
 
 /*-------------------------------------------------------------*
  | do_consult/2

--- a/core/alsp_src/builtins/blt_cslt.pro
+++ b/core/alsp_src/builtins/blt_cslt.pro
@@ -189,7 +189,8 @@ consult(What, Options)
 	:-
 	consult_global_options(Options, COpts),
 	consult_files(What, COpts),
-	builtins:refresh_spy_preds_if_showing.
+    	builtins:get_primary_manager(ALSMgr),
+        send(ALSMgr, refresh_wins).
 
 consult_files([], _) 
 	:-!.
@@ -451,17 +452,6 @@ cslt_info_recon(FileDesc, Nature, Nature, Recon, Recon, FileDesc).
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	%% MESSAGE LEVEL OF CONSULT 
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-/*-------------------------------------------------------------*
- | If in alsdev, check to refresh spy window (pred_info)
- | if needed.
- *-------------------------------------------------------------*/ 
-refresh_spy_preds_if_showing
-	:-
-	builtins:clause(alsdev_running,_),
-	!,
- 	tcl_call(shl_tcli, [refresh_spy_preds_if_showing], _).
-refresh_spy_preds_if_showing.
-
 
 
 /*-------------------------------------------------------------*
@@ -488,6 +478,7 @@ do_consult(BaseFile, FCOpts)
 			consult_except_resp(Ball,FCOpts,FileMgr,FinalMsg)
 	     ),
 	send(ALSMgr, set_value(cslt_ctxt, PrevCntxts)),
+%send(ALSMgr, refresh_wins),
 	record_consult(BaseFile, FCOpts, Ball, FileMgr, ALSMgr),
 	!,
 	consult_msg(FinalMsg, FCOpts).

--- a/core/alsp_src/builtins/blt_dvsh.pro
+++ b/core/alsp_src/builtins/blt_dvsh.pro
@@ -678,6 +678,10 @@ special_cl_processing(prolog_script, File, NoSuffixFile, Ext)
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+als_ide_mgrAction(refresh_wins, State)
+    	:-
+ 	tcl_call(shl_tcli, [refresh_spy_preds_if_showing], _).
+
 als_ide_mgrAction([Functor | Args], State)
 	:-
 	Msg =.. [Functor | Args],

--- a/core/alsp_src/builtins/debugger.pro
+++ b/core/alsp_src/builtins/debugger.pro
@@ -1460,6 +1460,10 @@ nospy(Pred/Arity) :-!,
 	functor(CallForm,Pred,Arity),
 	findall(M:CallForm-Tail, clause(spying_on(CallForm,M),Tail), L),
 	remove_spypoints(L).
+nospy(Pred) :-
+	atom(Pred),
+	findall(M:CallForm-Tail, (clause(spying_on(CallForm,M),Tail),functor(CallForm,Pred,_)), L),
+	remove_spypoints(L).
 
 nospy([]) :-!.
 nospy([Pat|More]) :-

--- a/core/alsp_src/builtins/debugger.pro
+++ b/core/alsp_src/builtins/debugger.pro
@@ -1146,6 +1146,7 @@ spy_pat(Module,Pred,Arity)
     dbg_spyoff,
     setup_debug(Module, Pred, Arity),
     install_spypoints(SpyList),
+    builtins:refresh_spy_preds_if_showing,
     setPrologInterrupt(spying),
     setDebugInterrupt(spying),
     printf(debugger_output,'Spy points set on: %t.\n', [SpyList]),

--- a/core/alsp_src/builtins/debugger.pro
+++ b/core/alsp_src/builtins/debugger.pro
@@ -1423,7 +1423,10 @@ export nospy/0.
         builtins:get_primary_manager(ALSMgr),
         send(ALSMgr, refresh_wins).
 
-remove_spypoints([]) :- !.
+remove_spypoints([]) :- 
+	!,
+    	builtins:get_primary_manager(ALSMgr),
+    	send(ALSMgr, refresh_wins).
 remove_spypoints([M:Call-Tail | More]) :-
     functor(Call,P,A),
     dbg_nospy(M,P,A),

--- a/core/alsp_src/builtins/debugger.pro
+++ b/core/alsp_src/builtins/debugger.pro
@@ -1146,7 +1146,8 @@ spy_pat(Module,Pred,Arity)
     dbg_spyoff,
     setup_debug(Module, Pred, Arity),
     install_spypoints(SpyList),
-    builtins:refresh_spy_preds_if_showing,
+    builtins:get_primary_manager(ALSMgr),
+    send(ALSMgr, refresh_wins),
     setPrologInterrupt(spying),
     setDebugInterrupt(spying),
     printf(debugger_output,'Spy points set on: %t.\n', [SpyList]),
@@ -1379,6 +1380,8 @@ nospy(Module,Predicate,Arity) :-
     (Condition = true -> retract(spying_on(CallForm,Module))
 		      ;  retract((spying_on(CallForm,Module) :- Condition))),
     check_spyoff,
+    builtins:get_primary_manager(ALSMgr),
+    send(ALSMgr, refresh_wins),
     printf(debugger_output,'Spy point removed for %t:%t/%t\n',
     		[Module,Predicate,Arity]), 
     !.
@@ -1416,7 +1419,9 @@ export nospy/0.
 'nospy' :-
 	dbg_spyoff,
 	findall(M:P-Tail, clause(spying_on(P,M),Tail), L),
-	remove_spypoints(L).
+	remove_spypoints(L),
+        builtins:get_primary_manager(ALSMgr),
+        send(ALSMgr, refresh_wins).
 
 remove_spypoints([]) :- !.
 remove_spypoints([M:Call-Tail | More]) :-

--- a/core/alsp_src/builtins/shlclass.pro
+++ b/core/alsp_src/builtins/shlclass.pro
@@ -77,6 +77,9 @@ module builtins.
 	%% GETTING A SOURCE MANAGER
 	%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+	%% In alspro, so nothing to do:
+als_shl_mgrAction(refresh_wins, State).
+
 als_shl_mgrAction(obtain_src_mgr(BaseFileName, FileMgr), State) 
 	:-!,
 	accessObjStruct(source_mgrs, State, PrevMgrsList),


### PR DESCRIPTION
The primary functionality this commit deals with is in alsdev:
Do Tools > Debugger, then Tools > Spy ; the Pred_info panel should be showing
Now in the prolog console, type: consult('<path to queens>/queens.pro').
Desired result:  The defined predicates from queens.pro should be immediately listed in the Predicates column of the pred_info panel.
Again in the prolog console, type spy all_queens.
Desired result: The Spying On column of pred_info should immediately contain all_queens/0.
Also:  none of this should impact consulting in alspro.
To verify:  All the combinations of consulting/spying with display in pred_info have been handled.