### PR TITLE
Provides solution for #101 on mac/darwin; needs testing on linux.

### DIFF
--- a/core/alsp_src/builtins/builtins.pro
+++ b/core/alsp_src/builtins/builtins.pro
@@ -1029,6 +1029,43 @@ exists_file(Path)
 	:-
 	'$access'(Path,0).
 
+/*!----------------------------------------------------------------
+ | getenv/2
+ | getenv(VarName, Value)
+ | getenv(+, -)
+ |
+ |	-- Get the value of a (named) environment variable
+ |
+ | 	Fails if the name variable is unset.
+ | The variable 'HOME' on Unix/Linux is treated specially:
+ | If 'HOME' is unset, the call to getenv succeeds, with
+ |	Value = <Path|To|alsdir>/user
+ | If the subdir 'user' of alsdir does not exist, it is created.
+ *!----------------------------------------------------------------*/
+
+export getenv/2.
+getenv('HOME', Value)
+	:-
+	getenv0('HOME', Value),
+	!.
+getenv('HOME', Value)
+	:-!,
+	sys_searchdir(AlsdirPath),
+	'$atom_concat'(AlsdirPath, 'user', UFileName),
+	Value = UFileName,
+	(exists(UFileName) -> 
+		true
+		;
+		get_cwd(CurWD),
+		change_cwd(AlsdirPath),
+		mkdir(user,511),
+		change_cwd(CurWD)
+	).
+getenv(Name, Value)
+	:-
+	getenv0(Name, Value).
+
+
 %% Temporary (backwards compat):
 export exists/1.
 exists(FileName) :-

--- a/core/alsp_src/generic/built.c
+++ b/core/alsp_src/generic/built.c
@@ -322,7 +322,7 @@ static struct blt_struct {
 #ifndef PURE_ANSI
 	BLT("$access", 2, pbi_access, "_pbi_access"),
 #ifdef OSACCESS
-	BLT("getenv", 2, pbi_getenv, "_pbi_getenv"),
+	BLT("getenv0", 2, pbi_getenv, "_pbi_getenv"),
 	BLT("get_user_home", 2, pbi_get_user_home, "_pbi_get_user_home"),
 	BLT("tmpnam", 1, pbi_tmpnam, "_pbi_tmpnam"),
 #endif /* OSACCESS */

--- a/core/alsp_src/tests/tsuite/test_command_line.sh
+++ b/core/alsp_src/tests/tsuite/test_command_line.sh
@@ -161,6 +161,10 @@ cl_test "$prolog -heap 2000 -heap 1000 -b -q -g 'statistics([_,_,heap(_,_,_,_,10
 cl_test "$prolog -stack 2000 -stack 1000 -b -q -g 'statistics([_,stack(_,_,1024000),_,_])'" 0
 cl_test "$prolog -stack 1000 -stack 2000 -b -q -g 'statistics([_,stack(_,_,2048000),_,_])'" 0
 
+# Test empty environment
+
+cl_test "env -i $prolog -q -b -g true" 0
+
 # test error handling of invalid ALS_OPTIONS
 # Currently they don't fail, but should:
 


### PR DESCRIPTION
When 'HOME' is unset, returns <path|to|alsdir>/user, creating that if needed.
All tests passed on darwin and linux.