### PR TITLE
Auto update copyright date in banner using export-subst.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,5 +8,5 @@ version
 # Tests use BTF files (Binary Text Files), which are binary.
 *.btf binary
 
-# Use export substitution to burn version info into source tarballs
+# Use export substitution to burn version and date info into source tarballs.
 version export-subst

--- a/core/alsp_src/builtins/blt_shl.pro
+++ b/core/alsp_src/builtins/blt_shl.pro
@@ -296,6 +296,7 @@ print_banner(OutS,L)
 	system_name(L, Name),
 	dmember(os_variation = OSVar, L),
 	dmember(prologVersion = Version, L),
+	dmember(prologYear = Year, L),
 	current_prolog_flag(windows_system, WinsName),
 	name(WinsName, [InC | WNCs]),
 	UInC is InC - 32,
@@ -306,7 +307,7 @@ print_banner(OutS,L)
 #else
 	printf(OutS,'%s Version %s \[%s\]\n',[Name,Version,OSVar]),
 #endif
-	printf(OutS,'   Copyright (c) 1987-2019 Applied Logic Systems, Inc.\n\n',[]),
+	printf(OutS,'   Copyright (c) 1987-%s Applied Logic Systems, Inc.\n\n',[Year]),
 	flush_output(OutS).
 
 system_name(L, Name)

--- a/core/alsp_src/generic/gnu_makefile
+++ b/core/alsp_src/generic/gnu_makefile
@@ -3,7 +3,7 @@ ALSDEVDIR=$(CORE)/als_dev/alsdev
 CORE=$(SOURCE_DIR)/..
 VPATH = $(SOURCE_DIR)/$(OS):$(SOURCE_DIR)/generic:$(SOURCE_DIR)/$(PROC):$(SOURCE_DIR)/smath:$(SOURCE_DIR)/builtins:$(SOURCE_DIR)/library:$(ALSDEVDIR):$(CORE)/tcltk_interface/common
 
-VERSION_FLAGS := -DVERSION=$(shell $(SOURCE_DIR)/../../version)
+VERSION_FLAGS := $(shell $(SOURCE_DIR)/../../version flags)
 
 default : binaries
 

--- a/core/alsp_src/generic/main.c
+++ b/core/alsp_src/generic/main.c
@@ -111,6 +111,7 @@ const char *version[2] = {
 #endif
 
 static char versionNum[] = VERSION_STRING;	/* from version.h */
+static char versionYear[] = VERSION_YEAR;	/* from version.h */
 /* static char systemName[] = SysName;		from version.h */
 static int exit_status = 0;
 static jmp_buf exit_return; 
@@ -123,7 +124,7 @@ static	void	abolish_predicate PARAMS(( const char *, const char *, int ));
 static	void	assert_sys_searchdir PARAMS(( char * ));
 static	void	assert_als_system PARAMS((const char *, const char *,
 					  const char *, const char *,
-					  const char *));
+					  const char *, const char *));
 static	void	assert_atom_in_module PARAMS(( const char*, const char * ));
 
 
@@ -431,7 +432,7 @@ static int PI_prolog_init0(const PI_system_setup *setup)
 
 #ifndef KERNAL
     assert_als_system(OSStr, MinorOSStr, ProcStr,
-		      SysManufacturer, versionNum);
+		      SysManufacturer, versionNum, versionYear);
 
     /*-------------------------------------------*
      | Set up conditional configuration controls:
@@ -616,8 +617,8 @@ assert_atom_in_module(mod_name,atom_name)
  |	loading the builtins file.
  *-----------------------------------------------------------------------------*/
 static void
-assert_als_system(os, os_var, proc, man, ver)
-    const char *os, *os_var, *proc, *man, *ver;
+assert_als_system(os, os_var, proc, man, ver, year)
+    const char *os, *os_var, *proc, *man, *ver, *year;
 {
     char  command[2048];
 
@@ -625,12 +626,13 @@ assert_als_system(os, os_var, proc, man, ver)
 		return;
 
     sprintf(command,
-	    "assertz(builtins,als_system([os='%s',os_variation='%s',processor='%s',manufacturer='%s',prologVersion='%s']),_,0)",
+	    "assertz(builtins,als_system([os='%s',os_variation='%s',processor='%s',manufacturer='%s',prologVersion='%s',prologYear='%s']),_,0)",
 	    os,
 	    os_var,
 	    proc,
 	    man,
-	    ver);
+	    ver,
+	    year);
     if (!exec_query_from_buf(command)) {
 		fatal_error(FE_ASSERT_SYS, 0);
     	}

--- a/core/alsp_src/generic/version.h
+++ b/core/alsp_src/generic/version.h
@@ -9,6 +9,7 @@
 #define _str(s) #s
 
 #define VERSION_STRING _xstr(VERSION)
+#define VERSION_YEAR   _xstr(YEAR)
 
 /* 
 Win32 File Flag choices:

--- a/version
+++ b/version
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-# Automagically calculate project version number from git tags
+# Automagically calculate project version number and copyright date from git
 
-# Archive hash and refs set by git-archive via export-subst in .gitattributes
+# Usage: version [version | year | flags]
+#   Options:
+#     version - (default) output version info
+#     year    - output copyright year
+#     flags   - output compiler flags to set VERSION and YEAR
+
+# Archive hash, refs and date set by git-archive via export-subst in .gitattributes
 
 # Note: the refs (%d) are truncated to only show the version tag, thus avoiding
 # variability caused by moving branch references (like master). This makes archives
@@ -12,17 +18,20 @@
 ARCHIVED='$Format:archived$'
 HASH='$Format:%h$'
 REFS='$Format:%<(13,ltrunc)%d$'
+DATE='$Format:%aI$'
 
 # Examples expansions:
 #ARCHIVED='archived'
 #HASH='09f863b'
 #REFS='..g: v1.2.3)'
+#DATE='1988-01-01...'
 
 VERSION='unknown'
+YEAR='????'
 
 case $ARCHIVED in
 
-# When archiving is detected, extract version from refs, or fall back to hash.
+# When archiving is detected, extract year from date and version from refs, or fall back to hash.
 archived)
 	if [[ $REFS =~ (v[^\)]+)\)$ ]]
 	then
@@ -30,13 +39,15 @@ archived)
 	else
 		VERSION=$HASH
 	fi
+	YEAR=${DATE:0:4}
 	;;		
 
-# Default to using git to generate version number in working tree
+# Default to using git to generate version number and year in working tree
 *)
 	if [[ $(git rev-parse --is-inside-work-tree) == 'true' ]]
 	then
 		VERSION=$(git describe --always --tags --dirty)
+		YEAR=$(git log -1 --date=format:%Y --pretty=format:%ad)
 	fi
 	;;
 	
@@ -48,4 +59,15 @@ then
 	VERSION=${VERSION:1}
 fi
 
-echo $VERSION
+# Send output based on option
+case ${1:-version} in
+version)
+	echo $VERSION
+	;;
+year)
+	echo $YEAR
+	;;
+flags)
+	echo -DVERSION=$VERSION -DYEAR=$YEAR
+	;;
+esac


### PR DESCRIPTION
Ideally, a source tree should always be *release-ready*. I.e. any commit can be version tagged (after review/testing). No source changes should be required before applying a version tag.

A concrete example: Imagine a project that released v1.2 last year. This year you notice a 1-line typo, and commit a fix. After review/testing, you should be able to just tag the commit as v1.2.1. No other changes to the source tree should be needed -- not even to copyright notices.

At the moment, the ALSProlog source code requires updating the copyright year in the banner before tagging a new version. This is an annoying and easily forgotten task that should be automated.

This pull request automates the copyright year based on the date of the last authored git commit via git's export-subst mechanism. We already use this mechanism to automate the display of version tags, so it is natural to extend it to handle copyright dates.

Downsides:
- Added complexity to the build and banner display.