### PR TITLE
Auto update copyright date in LICENSE.txt using export-subst.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,4 @@ version
 
 # Use export substitution to burn version info into source tarballs
 version export-subst
+LICENSE.txt export-subst

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 1985-2019 Applied Logic Systems, Inc.
+Copyright (c) $Format:1985-%<(6,trunc)%aI$.Applied Logic Systems, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/format-subst
+++ b/format-subst
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# format-subst <infile> [ <outfile> ]
+
+# Expands git's export-subst formatting placeholders in infile to outfile,
+# thus producing the same result as if infile had been git-archived.
+
+# Example:
+# $ ./format-subst LICENSE.txt
+# The MIT License (MIT)
+# Copyright (c) 1985-2019...Applied Logic Systems, Inc.
+# ...
+
+set -Eeuo pipefail
+
+INFILE=$1
+OUTFILE=${2:-/dev/stdout}
+
+# Only attempt substitution in a git tree, otherwise just cat-copy
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1
+then
+
+  # Extract text from infile, striped of export-subt $Format:...$ syntax
+  TEXT=$(sed 's/\$Format:\(.*\)\$/\1/g' "$INFILE")
+  # Use text as git-log formatting template to produce outfile
+  git log -1 --format="$TEXT" > "$OUTFILE"
+
+else
+
+  cat "$INFILE" > "$OUTFILE"
+
+fi

--- a/unix/build_dist.sh
+++ b/unix/build_dist.sh
@@ -62,7 +62,7 @@ for E in $EXAMPLE_SET ; do
 	cp -pr "$EXAMPLES/$E" "$DISTDIR/examples"
 done
 
-cp "$ALS_PROLOG/LICENSE.txt" "$DISTDIR/LICENSE.txt"
+../format-subst "$ALS_PROLOG/LICENSE.txt" "$DISTDIR/LICENSE.txt"
 cp -p "$MAN/welcome_standard.txt" "$DISTDIR/README.txt"
 cp -p $MAN/$MANUAL "$DISTDIR/$MANUALNAME"
 cp -p $MAN/$REFMANUAL "$DISTDIR/$REFMANUALNAME"

--- a/unix/package.sh
+++ b/unix/package.sh
@@ -41,7 +41,7 @@ cp -p $SRC/libalspro.a $DST/lib
 cp -p $SRC/alspro.1 $DST/share/man/man1/
 
 cp -p $SRC/README.txt $DST/share/doc/als-prolog
-cp -p $SRC/LICENSE.txt $DST/share/doc/als-prolog
+../format-subst $SRC/LICENSE.txt $DST/share/doc/als-prolog
 cp -p $SRC/als-prolog-manual.pdf $DST/share/doc/als-prolog
 cp -p $SRC/als-ref-manual.pdf $DST/share/doc/als-prolog
 cp -p $SRC/docs $DST/share/doc/als-prolog

--- a/win32/build_dist.sh
+++ b/win32/build_dist.sh
@@ -93,7 +93,7 @@ for E in $EXAMPLE_SET ; do
 	cp -pr "$EXAMPLES/$E" "$DISTDIR/examples"
 done
 
-cp "$ALS_PROLOG/LICENSE.txt" "$DISTDIR/LICENSE.txt"
+../format-subst "$ALS_PROLOG/LICENSE.txt" "$DISTDIR/LICENSE.txt"
 cp -p "$MAN/welcome_standard.txt" "$DISTDIR/README.txt"
 cp -p $MAN/$MANUAL "$DISTDIR/$MANUALNAME"
 cp -p $MAN/$REFMANUAL "$DISTDIR/$REFMANUALNAME"


### PR DESCRIPTION
See pull #153 for motivation.

This pull request automates the copyright year timestamp in the LICENSE.txt file.

Upsides:
- Never need to modify LICENSE.txt again.

Downsides:
- In git source, the license copyright date is the bizarro export-subst macro `$Format:...$`.
- In git-archived source and build packages, the license copyright date has an extra ".." at the end,
  which is the ellipsis added by the formatting macro (I haven't found a work-around to avoid this,
  so I've added another dot to make it look intentional).
- Added complexity to packaging.

Consider pulling only if we accept the downsides and can live with them.