### PR TITLE
Add simple test harness for use in all tests

### DIFF
--- a/core/alsp_src/generic/gnu_makefile
+++ b/core/alsp_src/generic/gnu_makefile
@@ -124,7 +124,7 @@ command_line_test: alspro
 	sh $(TEST_DIR)/tsuite/test_command_line.sh ./alspro
 
 test_suite: alspro
-	./alspro -s $(TEST_DIR) -giac -b autotest.pro atest_db.pro -g run_tests -p -srcdir $(SOURCE_DIR)
+	./alspro -no_obp -s $(TEST_DIR) -b autotest.pro atest_db.pro -g run_tests -p -srcdir $(SOURCE_DIR)
 
 test_app_image: alspro
 	$(TEST_DIR)/tsuite/test_app_image.sh

--- a/core/alsp_src/generic/gnu_makefile
+++ b/core/alsp_src/generic/gnu_makefile
@@ -124,7 +124,7 @@ command_line_test: alspro
 	sh $(TEST_DIR)/tsuite/test_command_line.sh ./alspro
 
 test_suite: alspro
-	./alspro -giac -b $(TEST_DIR)/autotest.pro $(TEST_DIR)/atest_db.pro -g run_tests -p -srcdir $(SOURCE_DIR)
+	./alspro -s $(TEST_DIR) -giac -b autotest.pro atest_db.pro -g run_tests -p -srcdir $(SOURCE_DIR)
 
 test_app_image: alspro
 	$(TEST_DIR)/tsuite/test_app_image.sh

--- a/core/alsp_src/tests/libtests/miscatom_test.pro
+++ b/core/alsp_src/tests/libtests/miscatom_test.pro
@@ -1,21 +1,20 @@
+:- [test].
+
 test_miscatom_lib
-        :-
+        :- test([
         test_catenate3,
         test_catenate2,
         test_trim_atoms,
-        true.
+        true
+        ]).
 
 test_catenate3 :-
         catenate(abc, def, Atom3),
         Atom3 == abcdef.
-test_catenate3 :-
-        printf(user, 'catenate3 test failed\n', []).
 
 test_catenate2 :-
         catenate([abc, def, ghty], Result),
         Result == abcdefghty.
-test_catenate2 :-
-        printf(user, 'catenate2 test failed\n', []).
 
 test_trim_atoms :-
         InAtoms = ['Abcd', gh768, bkdjfng, fr4],
@@ -23,8 +22,6 @@ test_trim_atoms :-
         trim_atoms(InAtoms, Sizes, Results),
                 % the truncation of gh768 is an atom:
         Results == [cd,'68',fng,''].
-test_trim_atoms :-
-        printf(user, 'trim_atoms test failed\n', []).
 
 test_cat_together_seplines :-
         List = [a,b,c,d],
@@ -39,38 +36,27 @@ test_cat_together_seplines :-
         cat_together_seplines(List, Result),
         Result == TgtResult.
 
-test_cat_together_seplines :-
-        printf(user, 'cat_together_seplines test failed\n', []).
-
 test_cat_together_spaced :-
         List = [a,b,c,d],
         cat_together_spaced(List, Result),
         Result == 'a b c d'.
-test_cat_together_spaced :-
-        printf(user, 'cat_together_spaced test failed\n', []).
 
 test_prefix_to :-
         List = [a1,b2,c3],
         Atom = 'Zip_',
         prefix_to(List, Atom, XList),
         XList == ['Zip_a1','Zip_b2','Zip_c3'].
-test_prefix_to :-
-        printf(user, 'prefix_to test failed\n', []).
 
 test_prefix_dir :-
         List = [foo, file3, bar],
         Dir = zipper,
         prefix_dir(List, Dir, XList),
         XList == ['zipper/foo','zipper/file3','zipper/bar'].
-test_prefix_dir :-
-        printf(user, 'prefix_dir test failed\n', []).
 
 test_strip_prefix :-
         List = [abcd, foobar, pop, f, zeroes],
         NN = 3,
         strip_prefix(List, NN, Result),
         Result == [d,bar,'','',oes].
-test_strip_prefix :-
-        printf(user, 'strip_prefix test failed\n', []).
 
 

--- a/core/alsp_src/tests/test.pro
+++ b/core/alsp_src/tests/test.pro
@@ -1,0 +1,38 @@
+/*
+
+Test - a simple, but colorful, test harness
+
+Example Usage:
+
+:- [test].
+
+mytest :- test([
+	(1 == 1),
+	(X is 1 + 1, X == 2),
+	(X = 1, X == 2)
+]).
+
+*/
+
+test(List) :-
+	test(List, Result),
+	Result.
+
+test([], true) :- !.
+test([], fail).
+test([true | Tail], Result) :- !, test(Tail, Result).
+test([Goal | Tail], Result) :-
+	O = user_output,
+	%% (atom(Goal) -> printf(O, '>>>> BEGIN %t <<<<\n', [Goal]) ; true ),
+	(
+		copy_term(Goal, RGoal),
+		catch(RGoal, Error, (write(O, 'Uncaught Error: '), write(O, Error), nl(O), fail)),
+		write(O, '\033[32m  OK: ')
+		;
+		Result=fail,
+		write(O, '\033[31mFAIL: ')
+	),
+	write_term(O, Goal, [quoted(true), line_length(180)]
+	),
+	write(O, '\033[0m'), nl(O),
+	!, test(Tail, Result).

--- a/core/alsp_src/tests/tsuite/curl_test.pro
+++ b/core/alsp_src/tests/tsuite/curl_test.pro
@@ -7,6 +7,8 @@ tsuite/echo/serve
 
 */
 
+:- [test].
+
 test :- test([
 	test_sio_url,
 	test_http,
@@ -16,28 +18,6 @@ test :- test([
 	
 	true
 ]).
-
-test(List) :-
-	test(List, Result),
-	Result.
-	
-test([], true) :- !.
-test([], fail).
-test([true | Tail], Result) :- !, test(Tail, Result).
-test([Goal | Tail], Result) :-
-	(atom(Goal) -> printf('>>>> BEGIN %t <<<<\n', [Goal]) ; true ),
-	(
-		copy_term(Goal, RGoal),
-		catch(RGoal, Error, (write('Uncaught Error: '), write(Error), nl, fail)),
-		write('\033[32m  OK: ')
-		;
-		Result=fail,
-		write('\033[31mFAIL: ')
-	),
-	write_term(Goal, [quoted(true), line_length(180)]
-	),
-	write('\033[0m'), nl,
-	!, test(Tail, Result).
 
 test_sio_url :- 
 	test([

--- a/core/alsp_src/tests/tsuite/curl_test.sh
+++ b/core/alsp_src/tests/tsuite/curl_test.sh
@@ -6,16 +6,17 @@ set -eux
 
 ALSPRO=$1
 
-TESTDIR=$(dirname "$0")
+TSUITE=$(dirname "$0")
+TESTDIR=$(dirname "$TSUITE")
 
 trap 'pkill -P $$ || true' EXIT
 
-"$TESTDIR"/echo/serve &
+"$TSUITE"/echo/serve &
 sleep 2
 
 if (( $debug ))
 then
-"$ALSPRO" "$TESTDIR"/curl_test.pro -g 'test ; true'
+"$ALSPRO" -s "$TESTDIR" "$TSUITE"/curl_test.pro -g 'test ; true'
 else
-"$ALSPRO" "$TESTDIR"/curl_test.pro -g test < /dev/null
+"$ALSPRO" -s "$TESTDIR" "$TSUITE"/curl_test.pro -g test < /dev/null
 fi

--- a/core/alsp_src/tests/tsuite/curl_test.sh
+++ b/core/alsp_src/tests/tsuite/curl_test.sh
@@ -16,7 +16,7 @@ sleep 2
 
 if (( $debug ))
 then
-"$ALSPRO" -s "$TESTDIR" "$TSUITE"/curl_test.pro -g 'test ; true'
+"$ALSPRO" -no_obp -s "$TESTDIR" "$TSUITE"/curl_test.pro -g 'test ; true'
 else
-"$ALSPRO" -s "$TESTDIR" "$TSUITE"/curl_test.pro -g test < /dev/null
+"$ALSPRO" -no_obp -s "$TESTDIR" "$TSUITE"/curl_test.pro -g test < /dev/null
 fi


### PR DESCRIPTION
This pull refactors the simple test rig from curl_test to make it available for all tests, and converts one example test (`miscatom_test.pro`) to use the new test rig.

### Motivation

Many current tests only print a message when they fail (e.g. `miscatom_test.pro`), so errors can only be detected by manual examination of the test log. The test harness automates the detection of test failures and reporting. Plus it color codes results!

