### PR TITLE
Extended ~tests/test.pro to simplify output in cases like ~libtests/r…

### DIFF
--- a/core/alsp_src/tests/libtests/miscatom_test.pro
+++ b/core/alsp_src/tests/libtests/miscatom_test.pro
@@ -5,6 +5,11 @@ test_miscatom_lib
         test_catenate3,
         test_catenate2,
         test_trim_atoms,
+	test_cat_together_seplines,
+	test_cat_together_spaced,
+	test_prefix_to,
+	test_prefix_dir,
+	test_strip_prefix,
         true
         ]).
 

--- a/core/alsp_src/tests/libtests/read_examp_toks.pro
+++ b/core/alsp_src/tests/libtests/read_examp_toks.pro
@@ -1,3 +1,4 @@
+:- [test].
 
 read_toks
 	:-
@@ -11,8 +12,9 @@ read_toks
 		Path1 = '../../alsp_src/tests/libtests/example.com',
 		Path2 = '../../alsp_src/tests/libtests/sample_awstats.html'
 	),
-	do_read_toks(OS, Path1, NTks1),
-	do_read_toks(OS, Path2, NTks2).
+	test([
+	read_toks(NTks1)/do_read_toks(OS, Path1, NTks1),
+	read_toks(NTks2)/do_read_toks(OS, Path2, NTks2) ]).
 
 do_read_toks(OS, Path, NTks)
 	:-

--- a/core/alsp_src/tests/test.pro
+++ b/core/alsp_src/tests/test.pro
@@ -12,6 +12,10 @@ mytest :- test([
 	(X = 1, X == 2)
 ]).
 
+Also, allows
+	.... test([Note1/Goal1, Note2/Goal2, ....])
+where Note1[2] will be printed out instead of Goal1[2] --
+	-- simplifies output in cases like: libtests/read_examp_toks.pro.
 */
 
 test(List) :-
@@ -21,7 +25,16 @@ test(List) :-
 test([], true) :- !.
 test([], fail).
 test([true | Tail], Result) :- !, test(Tail, Result).
+
+test([Notation/Goal | Tail], Result) :-
+	manage_test(Goal, Notation, Result, Tail),
+	!, test(Tail, Result).
+
 test([Goal | Tail], Result) :-
+	manage_test(Goal, Result, Tail),
+	!, test(Tail, Result).
+
+manage_test(Goal, Result, Tail) :-
 	O = user_output,
 	%% (atom(Goal) -> printf(O, '>>>> BEGIN %t <<<<\n', [Goal]) ; true ),
 	(
@@ -34,5 +47,20 @@ test([Goal | Tail], Result) :-
 	),
 	write_term(O, Goal, [quoted(true), line_length(180)]
 	),
-	write(O, '\033[0m'), nl(O),
-	!, test(Tail, Result).
+	write(O, '\033[0m'), nl(O).
+
+manage_test(Goal, Notation, Result, Tail) :-
+	O = user_output,
+	%% (atom(Goal) -> printf(O, '>>>> BEGIN %t <<<<\n', [Goal]) ; true ),
+	(
+		copy_term(Goal, RGoal),
+		catch(RGoal, Error, (write(O, 'Uncaught Error: '), write(O, Error), nl(O), fail)),
+		write(O, '\033[32m  OK: ')
+		;
+		Result=fail,
+		write(O, '\033[31mFAIL: ')
+	),
+	write_term(O, Notation, [quoted(true), line_length(180)]
+	),
+	write(O, '\033[0m'), nl(O).
+


### PR DESCRIPTION
…ead_examp_toks.pro, as in

read_toks
        :-
        sys_env(OS,_,_),
        NTks1 = 226,
        NTks2 = 919,
        (OS = mswin32 ->
                Path1 = '../alsp_src/tests/libtests/example.com',
                Path2 = '../alsp_src/tests/libtests/sample_awstats.html'
                ;
                Path1 = '../../alsp_src/tests/libtests/example.com',
                Path2 = '../../alsp_src/tests/libtests/sample_awstats.html'
        ),
        test([
            read_toks(NTks1)/do_read_toks(OS, Path1, NTks1),
            read_toks(NTks2)/do_read_toks(OS, Path2, NTks2) ]).