### PR TITLE
Remove $strlen, in favor of atom_length

### DIFF
--- a/core/alsp_src/builtins/sio.pro
+++ b/core/alsp_src/builtins/sio.pro
@@ -1676,7 +1676,7 @@ open_atom_stream(Atom,read,Options,Stream) :-
 	initialize_stream(atom,atom(Atom),Options,Stream),
 	set_stream_extra(Stream,Atom),
 	set_stream_addl1(Stream,0),
-	'$strlen'(Atom,ALen),
+	atom_length(Atom,ALen),
 	set_stream_addl2(Stream,ALen),
 	file_modes(read,NMode,SMode),
 	set_stream_mode(Stream,SMode),

--- a/core/alsp_src/builtins/sio_wt.pro
+++ b/core/alsp_src/builtins/sio_wt.pro
@@ -1199,7 +1199,7 @@ scan(Char,T,Count,Breaks,LineLen,BreakLev,ILL,EL) :-
 scan(Atom,T,Count,Breaks,LineLen,BreakLev,ILL,EL) :-
 	atom(Atom),
 	!,
-	'$strlen'(Atom,AtomLength),
+	atom_length(Atom,AtomLength),
 	NewCount is Count+AtomLength,
 	scan(T,NewCount,Breaks,LineLen,BreakLev,ILL,EL).
 
@@ -1307,7 +1307,7 @@ insertBreak(_,Pri,H,T,Break,[H|NewT]) :-
     
 breakCount(break(_,_,_,_),false,1) :- !.
 breakCount(break(_,_,_,_),_,0) :- !.
-breakCount(spop(_,_,Atom,_),_,N) :- '$strlen'(Atom,NC), !, N is NC+2.
+breakCount(spop(_,_,Atom,_),_,N) :- atom_length(Atom,NC), !, N is NC+2.
 breakCount(space(_,_,_,_),_,1).
 
 
@@ -1407,7 +1407,7 @@ os2(spop(Pri,break,Atom,_IL),T,Stream,IL,II)
 	tab(Stream,II),
 	indent(Stream,ILP),
 	put_atom(Stream,Atom),
-	'$strlen'(Atom,AtomLength),
+	atom_length(Atom,AtomLength),
 	TabWidth is 4-AtomLength,
 	tab(Stream,TabWidth),
 	!,

--- a/core/alsp_src/generic/bparser.c
+++ b/core/alsp_src/generic/bparser.c
@@ -851,26 +851,6 @@ pbi_uia_size()
 	FAIL;
 }
 
-
-int
-pbi_strlen()
-{				/* $strlen(Symbol,Size) */
-    PWord v1, v2;
-    int   t1, t2;
-    UCHAR *str;
-
-    w_get_An(&v1, &t1, 1);
-    w_get_An(&v2, &t2, 2);
-
-    if (!getstring(&str, v1, t1))
-	FAIL;
-
-    if (w_unify(v2, t2, (PWord) strlen((char *)str), WTP_INTEGER))
-	SUCCEED;
-    else
-	FAIL;
-}
-
 int
 get_number(v, t, val)
     PWord v;

--- a/core/alsp_src/generic/built.c
+++ b/core/alsp_src/generic/built.c
@@ -316,7 +316,6 @@ static struct blt_struct {
 	BLT("$uia_pokel", 3, pbi_uia_pokel, "_pbi_uia_pokel"),
 	BLT("$uia_poked", 3, pbi_uia_poked, "_pbi_uia_poked"),
 	BLT("$uia_pokes", 3, pbi_uia_pokes, "_pbi_uia_pokes"),
-	BLT("$strlen", 2, pbi_strlen, "_pbi_strlen"),
 	BLT("$atom_concat", 3, pbi_atom_concat, "_pbi_atom_concat"),
 
 #ifndef PURE_ANSI

--- a/core/alsp_src/generic/built.h
+++ b/core/alsp_src/generic/built.h
@@ -318,7 +318,6 @@ extern	int	pbi_uia_pokew	PARAMS(( void ));
 extern	int	pbi_uia_pokel	PARAMS(( void ));
 extern	int	pbi_uia_poked	PARAMS(( void ));
 extern	int	pbi_uia_pokes	PARAMS(( void ));
-extern	int	pbi_strlen	PARAMS(( void ));
 extern	int	pbi_atom_concat	PARAMS(( void ));
 
 /* bsio.c */

--- a/core/alsp_src/library/mscioout.pro
+++ b/core/alsp_src/library/mscioout.pro
@@ -56,7 +56,7 @@ colwrite([Item | Items], [NextColPos | RestColStarts], CurPos, Stream)
     CurPos < NextColPos,
     !,
 	(atom(Item) -> 
-		'$strlen'(Item, ItemLen)
+		atom_length(Item, ItemLen)
 		;
 		name(Item,ICs),length(ICs,ItemLen)
 	),

--- a/core/alsp_src/pconfig/mkdist.pro
+++ b/core/alsp_src/pconfig/mkdist.pro
@@ -302,7 +302,7 @@ get_params(ARCH,OS,Vers,Srcdir)
 	
 read_to(Tag,MFS,Line)
 	:-
-	'$strlen'(Tag,TagLen),
+	atom_length(Tag,TagLen),
 	read_to(Tag,TagLen,MFS,Line).
 
 read_to(Tag,TagLen,MFS,Line)

--- a/docs/docs/guide/7-Working-with-Uninterned-Atoms.md
+++ b/docs/docs/guide/7-Working-with-Uninterned-Atoms.md
@@ -193,13 +193,6 @@ If Size is less than or equal to the actual size of the given UIABuf, the call
 reduces the size of UIABuf by removing all but one of the trailing zeros (null
 bytes). 
 
-When Atom is a Prolog atom (symbol or UIA),
-
-    '$strlen(Atom,Size)'
-
-returns the length of the print name of that atom (thus not counting the terminating
-null byte).
-
 ## 7.4 Observations on Using UIAs
 
 As indicated by the rules presented in Section 7.2 (Interning UIAs) , ALS Prolog

--- a/docs/docs/ref/uia_alloc.md
+++ b/docs/docs/ref/uia_alloc.md
@@ -18,7 +18,6 @@ predicates:
 - {sig: '$uia_peeks/4', desc: 'returns the specified substring of a UIA'}
 - {sig: '$uia_peek/4', desc: 'returns the specified region of a UIA'}
 - {sig: '$uia_poke/4', desc: 'modifies the specified region of a UIA'}
-- {sig: '$strlen/2', desc: 'returns the length of the specified symbol'}
 ---
 
 ## FORMS
@@ -48,8 +47,6 @@ predicates:
 
 '$uia_peek'(UIABuf, Offset, Size, Value)
 '$uia_poke'(UIABuf, Offset, Size, Value)
-
-'$strlen'(Symbol, Size)
 ```
 
 ## DESCRIPTION
@@ -69,8 +66,6 @@ Like `'$uia_pokeb'/3`, `'$uia_pokes'/3` views the buffer as a vector of bytes wi
 Provided that `Offset` and `Size` define a proper region within the given `UIABuf` (i.e., not including the final byte of `UIABuf`), `'$uia_poke'(UIABuf, Offset, Size, Value)` modifies the indicated region by copying characters from the given UIA (or symbol) `Value`. The size of the atom or UIA `Value` must be greater than or equal to `Size`. The region copied from `Value` is defined by offset 0 and `Size`.
 
 Provided that `Offset` and `Size` define a proper region within the given `UIABuf` (i.e., not including the final byte of `UIABuf`), `'$uia_peek'(UIABuf, Offset, Size, Value)` extracts the indicated region from `UIABuf`, returning it as a new UIA `Value`.
-
-When `Symbol` is a Prolog symbol (atom or UIA), `'$strlen'(Symbol, Size)` returns the length of the print name of that symbol (thus not counting the terminating null byte).
 
 
 ## EXAMPLES


### PR DESCRIPTION
See commits for reasons in favor of deprecation/removal. Major question for review:

- Is backward compatibility needed? The current PR completely eliminates `$strlen` within ALS Prolog. Are there large bodies of external code that rely on `$strlen`, that require a compatibility shim?