### PR TITLE
Refactor ISO links into	ref-page layout.

### DIFF
--- a/docs/_layouts/reference-page.html
+++ b/docs/_layouts/reference-page.html
@@ -25,4 +25,9 @@ layout: default
 {%- endfor %}
 </p>
 
+{% if page.iso -%}
+<p><a href="https://www.deransart.fr/prolog/bips.html#{{page.iso}}">ISO Standard Predicate</a></p>
+
+{% endif -%}
+
 {{ content }}

--- a/docs/docs/ref/abolish.md
+++ b/docs/docs/ref/abolish.md
@@ -1,5 +1,6 @@
 ---
 title: 'abolish/2'
+iso: abolish
 predicates:
 - {sig: 'abolish', args: {
     1: 'remove a procedure from the database',
@@ -7,7 +8,6 @@ predicates:
     3: 'remove a procedure from the database'
   }}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#abolish)
 
 ## FORMS
 

--- a/docs/docs/ref/arg.md
+++ b/docs/docs/ref/arg.md
@@ -1,12 +1,10 @@
 ---
 title: 'arg/3'
 group: Terms
+iso: arg
 predicates:
 - {sig: 'arg/3', desc: 'access the arguments of a structured term'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#arg)
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/arrow.md
+++ b/docs/docs/ref/arrow.md
@@ -1,11 +1,9 @@
 ---
 title: '->/2(arrow)'
+iso: ifthen
 predicates:
 - {sig: '->/2', desc: 'if-then, and if-then-else'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#ifthen)
-
-
 
 ## FORMS
 

--- a/docs/docs/ref/assert.md
+++ b/docs/docs/ref/assert.md
@@ -1,6 +1,7 @@
 ---
 title: 'assert/[1,2]'
 group: Prolog Database
+iso: assertz
 predicates:
 - {sig: 'assert', args: { 
     1: 'adds a clause to a procedure',
@@ -15,14 +16,6 @@ predicates:
     2: 'adds a clause to the end of a procedure, returning a DB Ref'
   }}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#assertz)
-
-
-
-
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/at_end_of_stream.md
+++ b/docs/docs/ref/at_end_of_stream.md
@@ -2,20 +2,13 @@
 title: 'at_end_of_stream/[0,1]'
 group: Input Output
 module: sio
+iso: streamproperty
 predicates:
 - {sig: 'at_end_of_stream', args: {
      0: 'test for end of the curent input stream',
      1: 'test for end of a specific input stream'
    }}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#streamproperty)
-
-
-
-
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/atom.md
+++ b/docs/docs/ref/atom.md
@@ -1,6 +1,7 @@
 ---
 title: 'atom/1'
 group: Terms
+iso: number
 predicates:
 - {sig: 'atom/1', desc: 'the term is an atom'}
 - {sig: 'atomic/1', desc: 'the term is an atom or a number'}
@@ -8,23 +9,6 @@ predicates:
 - {sig: 'integer/1', desc: 'the term is an integer'}
 - {sig: 'number/1', desc: 'the term is an integer or a floating point'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#number)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/atom_chars.md
+++ b/docs/docs/ref/atom_chars.md
@@ -1,18 +1,11 @@
 ---
 title: 'atom_chars/2'
 group: Terms
+iso: atomcodes
 predicates:
 - {sig: 'atom_chars/2', desc: 'convert between atoms and the list of characters representing the atom'}
 - {sig: 'atom_codes/2', desc: 'convert between atoms and the list of character codes representing the atom'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#atomcodes)
-
-
-
-
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/call.md
+++ b/docs/docs/ref/call.md
@@ -1,11 +1,9 @@
 ---
 title: 'call/1'
+iso: call
 predicates:
 - {sig: 'call/1', desc: 'calls a goal'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#call)
-
-
 
 ## FORMS
 

--- a/docs/docs/ref/canonorder.md
+++ b/docs/docs/ref/canonorder.md
@@ -1,16 +1,13 @@
 ---
 title: '@=</2'
 group: Terms
+iso: termcomp
 predicates:
 - {sig: '@=</2', desc: 'The left argument is not after the right argument'}
 - {sig: '@>=/2', desc: 'The left argument is not before the right argument'}
 - {sig: '@</2', desc: 'The left argument is before the right argument'}
 - {sig: '@>/2', desc: 'The left argument is after the right argument'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#termcomp)
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/catch.md
+++ b/docs/docs/ref/catch.md
@@ -1,14 +1,10 @@
 ---
 title: 'catch/3'
+iso: catch
 predicates:
 - {sig: 'catch/3', desc: 'execute a goal, specifying an exception handler'}
 - {sig: 'throw/1', desc: 'give control to an exception handler'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#catch)
-
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/char_code.md
+++ b/docs/docs/ref/char_code.md
@@ -1,12 +1,10 @@
 ---
 title: 'char_code/2'
 group: Terms
+iso: charcode
 predicates:
 - {sig: 'char_code/2', desc: 'convert between characters and codes'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#charcode)
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/close.md
+++ b/docs/docs/ref/close.md
@@ -2,18 +2,13 @@
 title: 'close/1'
 group: Input Output
 module: sio
+iso: close
 predicates:
 - {sig: 'close', args: {
      1: 'close an open stream',
      2: 'close an open stream with options'
    }}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#close)
-
-
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/comma.md
+++ b/docs/docs/ref/comma.md
@@ -1,11 +1,9 @@
 ---
 title: ',/2 (comma)'
+iso: and
 predicates:
 - {sig: ',/2', desc: 'conjunction of two goals'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#and)
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/copy_term.md
+++ b/docs/docs/ref/copy_term.md
@@ -1,12 +1,10 @@
 ---
 title: 'copy_term/2'
 group: Terms
+iso: copyterm
 predicates:
 - {sig: 'copy_term/2', desc: 'make copy of a term'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#copyterm)
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/current_input.md
+++ b/docs/docs/ref/current_input.md
@@ -2,16 +2,11 @@
 title: 'current_input/1'
 group: Input Output
 module: sio
+iso: currentoutput
 predicates:
 - {sig: 'current_input/1', desc: 'retrieve current input stream'}
 - {sig: 'current_output/1', desc: 'retrieve current output stream'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#currentoutput)
-
-
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/current_op.md
+++ b/docs/docs/ref/current_op.md
@@ -1,12 +1,10 @@
 ---
 title: 'current_op/3'
 module: sio
+iso: operators
 predicates:
 - {sig: 'current_op/3', desc: 'retrieve current operator definitions'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#operators)
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/cut.md
+++ b/docs/docs/ref/cut.md
@@ -1,9 +1,9 @@
 ---
 title: '!/0'
+iso: cut
 predicates:
 - {sig: '!/0', desc: '(cut) removes choice points'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#cut)
 
 ## FORMS
 ```

--- a/docs/docs/ref/fail.md
+++ b/docs/docs/ref/fail.md
@@ -1,11 +1,9 @@
 ---
 title: 'fail/0'
+iso: fail
 predicates:
 - {sig: 'fail/0', desc: 'always fails'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#fail)
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/functor.md
+++ b/docs/docs/ref/functor.md
@@ -1,12 +1,10 @@
 ---
 title: 'functor/3'
 group: Terms
+iso: functor
 predicates:
 - {sig: 'functor/3', desc: 'builds structures and retrieves information about them'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#functor)
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/get_char.md
+++ b/docs/docs/ref/get_char.md
@@ -2,18 +2,13 @@
 title: 'get_char/[1,2]'
 group: Input Output
 module: sio
+iso: getchar
 predicates:
 - {sig: 'get_char', args: {
     1: 'read a character from current input stream',
     2: 'read character from a specific stream'
   }}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#getchar)
-
-
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/get_code.md
+++ b/docs/docs/ref/get_code.md
@@ -2,18 +2,13 @@
 title: 'get_code/[1,2]'
 group: Input Output
 module: sio
+iso: getcode
 predicates:
 - {sig: 'get_code', args: {
     1: 'read a character code from current input stream',
     2: 'read character code from a specific stream'
   }}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#getcode)
-
-
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/halt.md
+++ b/docs/docs/ref/halt.md
@@ -1,11 +1,9 @@
 ---
 title: 'halt/0'
+iso: halt
 predicates:
 - {sig: 'halt/0', desc: 'exit ALS Prolog'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#halt)
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/identity.md
+++ b/docs/docs/ref/identity.md
@@ -1,12 +1,11 @@
 ---
 title: '==/2'
 group: Terms
+iso: termcomp
 predicates:
 - {sig: '==/2', desc: 'terms are identical'}
 - {sig: '\==/2', desc: 'terms are not identical'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#termcomp)
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/not.md
+++ b/docs/docs/ref/not.md
@@ -1,12 +1,10 @@
 ---
 title: 'not/1'
+iso: notprovable
 predicates:
 - {sig: 'not/1', desc: 'tests whether a goal fails'}
 - {sig: '\+/1', desc: 'tests whether a goal fails'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#notprovable)
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/number_chars.md
+++ b/docs/docs/ref/number_chars.md
@@ -1,16 +1,11 @@
 ---
 title: 'number_chars/2'
 group: Terms
+iso: numbercodes
 predicates:
 - {sig: 'number_chars/2', desc: 'convert between a number and the list of characters which represent the number'}
 - {sig: 'number_codes/2', desc: 'convert between a number and the list of character codes which represent the number'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#numbercodes)
-
-
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/op.md
+++ b/docs/docs/ref/op.md
@@ -1,12 +1,10 @@
 ---
 title: 'op/3'
 module: sio
+iso: operators
 predicates:
 - {sig: 'op/3', desc: 'define operator associativity and precedence'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#operators)
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/open.md
+++ b/docs/docs/ref/open.md
@@ -2,18 +2,13 @@
 title: 'open/[3,4]'
 group: Input Output
 module: sio
+iso: open
 predicates:
 - {sig: 'open', args: {
     3: 'open a stream',
     4: 'open a stream with options'
    }}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#open)
-
-
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/peek_code.md
+++ b/docs/docs/ref/peek_code.md
@@ -2,18 +2,13 @@
 title: 'peek_code/[1,2]'
 group: Input Output
 module: sio
+iso: peekcode
 predicates:
 - {sig: 'peek_code', args: {
     1: 'obtain char code from stream',
     2: 'obtain char from stream'
    }}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#peekcode)
-
-
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/put_char.md
+++ b/docs/docs/ref/put_char.md
@@ -2,18 +2,13 @@
 title: 'put_char/[1,2]'
 group: Input Output
 module: sio
+iso: putchar
 predicates:
 - {sig: 'put_char', args: {
     1: 'output a character to the current output stream',
     2: 'output a character to a specific output stream'
   }}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#putchar)
-
-
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/put_code.md
+++ b/docs/docs/ref/put_code.md
@@ -2,18 +2,13 @@
 title: 'put_code/[1,2]'
 group: Input Output
 module: sio
+iso: putchar
 predicates:
 - {sig: 'put_code', args: {
     1: 'output a character code to the current output stream',
     2: 'output a character code to a specific output stream'
   }}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#putchar)
-
-
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/read.md
+++ b/docs/docs/ref/read.md
@@ -2,6 +2,7 @@
 title: 'read/[1,2]'
 group: Input Output
 module: sio
+iso: readterm
 predicates:
 - {sig: 'read', args: {
     1: 'read a term from the current input stream',
@@ -12,18 +13,6 @@ predicates:
     3: 'read term from specified stream with options'
   }}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#readterm)
-
-
-
-
-
-
-
-
-
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/repeat.md
+++ b/docs/docs/ref/repeat.md
@@ -1,11 +1,9 @@
 ---
 title: 'repeat/0'
+iso: repeat
 predicates:
 - {sig: 'repeat/0', desc: 'always succeed upon backtracking'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#repeat)
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/retract.md
+++ b/docs/docs/ref/retract.md
@@ -1,6 +1,7 @@
 ---
 title: 'retract/[1,2]'
 group: Prolog Database
+iso: retract
 predicates:
 - {sig: 'retract', args: {
     1: 'removes a clause from the database',
@@ -8,9 +9,6 @@ predicates:
   }}
 - {sig: 'erase/1', desc: 'removes a clause from the database'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#retract)
-
-
 
 ## FORMS
 ```

--- a/docs/docs/ref/semicolon.md
+++ b/docs/docs/ref/semicolon.md
@@ -1,11 +1,9 @@
 ---
 title: ';/2 (semi-colon)'
+iso: or
 predicates:
 - {sig: ';/2', desc: 'disjunction of two goals'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#or)
-
-
 
 ## FORMS
 

--- a/docs/docs/ref/set_input.md
+++ b/docs/docs/ref/set_input.md
@@ -2,16 +2,11 @@
 title: 'set_input/1'
 group: Input Output
 module: sio
+iso: setoutput
 predicates:
 - {sig: 'set_input/1', desc: 'set current input stream'}
 - {sig: 'set_output/1', desc: 'set current output stream'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#setoutput)
-
-
-
-
-
 
 ## FORMS
 

--- a/docs/docs/ref/set_stream_position.md
+++ b/docs/docs/ref/set_stream_position.md
@@ -2,12 +2,10 @@
 title: 'set_stream_position/2'
 group: Input Output
 module: sio
+iso: setstreamposition
 predicates:
 - {sig: 'set_stream_position/2', desc: 'seek to a new position in a stream'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#setstreamposition)
-
-
 
 ## FORMS
 

--- a/docs/docs/ref/setof.md
+++ b/docs/docs/ref/setof.md
@@ -1,20 +1,12 @@
 ---
 title: 'setof/3'
+iso: setof
 predicates:
 - {sig: 'setof/3', desc: 'all unique solutions for a goal, sorted'}
 - {sig: 'bagof/3', desc: 'all solutions for a goal, not sorted'}
 - {sig: 'findall/3', desc: 'all solutions for a goal, not sorted'}
 - {sig: 'b_findall/4', desc: 'bound list of solutions for a goal, not sorted'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#setof)
-
-
-
-
-
-
-
-
 
 ## FORMS
 

--- a/docs/docs/ref/stream_property.md
+++ b/docs/docs/ref/stream_property.md
@@ -2,12 +2,10 @@
 title: 'stream_property/2'
 group: Input Output
 module: sio
+iso: streamproperty
 predicates:
 - {sig: 'stream_property/2', desc: 'retrieve streams and their properties'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#streamproperty)
-
-
 
 ## FORMS
 

--- a/docs/docs/ref/sub_atom.md
+++ b/docs/docs/ref/sub_atom.md
@@ -1,12 +1,10 @@
 ---
 title: 'sub_atom/5'
 group: Terms
+iso: subatom
 predicates:
 - {sig: 'sub_atom/5', desc: 'dissect an atom'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#subatom)
-
-
 
 ## FORMS
 

--- a/docs/docs/ref/true.md
+++ b/docs/docs/ref/true.md
@@ -1,11 +1,9 @@
 ---
 title: 'true/0'
+iso: true
 predicates:
 - {sig: 'true/0', desc: 'always succeeds'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#true)
-
-
 
 ## FORMS
 

--- a/docs/docs/ref/unify.md
+++ b/docs/docs/ref/unify.md
@@ -1,14 +1,11 @@
 ---
 title: '=/2'
 group: Terms
+iso: termcomp
 predicates:
 - {sig: '=/2', desc: 'unify two terms'}
 - {sig: '\=/2', desc: 'test if two items are non-unifiable'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#termcomp)
-
-
-
 
 ## FORMS
 

--- a/docs/docs/ref/univ.md
+++ b/docs/docs/ref/univ.md
@@ -1,14 +1,10 @@
 ---
 title: '=..(univ)'
 group: Terms
+iso: univ
 predicates:
 - {sig: '=../2', desc: 'composes/decomposes structures from/to components'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#univ)
-
-
-
-
 
 ## FORMS
 

--- a/docs/docs/ref/var.md
+++ b/docs/docs/ref/var.md
@@ -1,16 +1,11 @@
 ---
 title: 'var/1'
 group: Prolog Database
+iso: var
 predicates:
 - {sig: 'var/1', desc: 'the variable is unbound'}
 - {sig: 'nonvar/1', desc: 'the variable is instantiated'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#var)
-
-
-
-
-
 
 ## FORMS
 

--- a/docs/docs/ref/write.md
+++ b/docs/docs/ref/write.md
@@ -2,6 +2,7 @@
 title: 'write/[1,2]'
 group: Input Output
 module: sio
+iso: write_term
 predicates:
 - {sig: 'write', args:
     {1: 'write term to current output stream', 2: 'write term to specified stream'}}
@@ -22,18 +23,6 @@ predicates:
   }}
 - {sig: 'display/1', desc: 'write term to current output stream in canonical form'}
 ---
-[ISO Standard Predicate](https://www.deransart.fr/prolog/bips.html#write_term)
-
-
-
-
-
-
-
-
-
-
-
 
 ## FORMS
 


### PR DESCRIPTION
Factoring the link out into the layout allows for easier maintenance, and consistent
rendering. Future redesign of the link text/position/styling is also made simpler.

This pull request is a pure refactoring: the generated doc is identical to existing doc. I'd like to have this pull accepted before fixing a few missing ISO link.

Originally mention in: `message://%3cFAFFA9FF-ABBF-4854-8D04-195A73DFA497@habilis.net%3e`