### PR TITLE
Correct feature flags to avoid disabling local rexec/2 on Darwin.

### DIFF
--- a/core/alsp_src/unix/darwin_config.h
+++ b/core/alsp_src/unix/darwin_config.h
@@ -1,6 +1,6 @@
 #define MinorOSStr	"darwin"
 
-#undef REXEC
+#undef HAVE_REXEC
 #define EXTERNAL_STATE 1
 #define MAP_ANONYMOUS MAP_ANON
 #if 0

--- a/docs/docs/ref/rexec.md
+++ b/docs/docs/ref/rexec.md
@@ -32,7 +32,7 @@ If none of host, username, or password are specified, then `rexec/2` will use th
 ## EXAMPLES
 
 The following procedure will call the unix word count program, wc, to determine the length of an atom.
-[[FAILS on macOS 10.12.6]]
+
 ```
 slow_atom_length(A, Len) 
     :-
@@ -47,7 +47,7 @@ Len=17
 yes.
 ```
 
-The version of `slow_atom_length/2` above assumes one is running on a Unix machine and calls wc running on the same machine. The version below, `slow_atom_length/3`, will work on any system which supports sockets (Unix workstations, Windows 95 with WinSock, Macintosh):
+The version of `slow_atom_length/2` above assumes one is running on a Unix machine and calls wc running on the same machine. The version below, `slow_atom_length/3`, will work on systems that support the `rexec`/`rexecd` client-server remote execution protocol (now deprecated):
 ```
 rstrlen(Host, A, Len) 
     :-


### PR DESCRIPTION
Confusion over the meaning of the REXEC (rexec/2 pred) vs HAVE_REXEC (BSD sys call)
feature flags caused rexec/2 to be completely disabled on Darwin (macOS).
Darwin doesn't ship with the rexec/rexecd system, but it does support the
fork/exec-ing used by the local form of rexec/2. Thus REXEC is on, but
HAVE_REXEC is off.

Resolves #134