### PR TITLE
Remove defunct PARAMS and CONST macro for K&R C.

### DIFF
--- a/core/alsp_src/generic/alloc.c
+++ b/core/alsp_src/generic/alloc.c
@@ -21,7 +21,7 @@ pwrd  nil_val =
 pword prs_area;
 static pword areap;
 
-static	pword	allocat	PARAMS(( size_t ));
+static	pword	allocat	( size_t );
 
 void
 prs_area_init(marksize)

--- a/core/alsp_src/generic/alloc.h
+++ b/core/alsp_src/generic/alloc.h
@@ -186,19 +186,19 @@ extern pwrd nil_val;
 #define MK_UIA(s) mk_uia(s)
 #define UIA_NAME(v) ((char *) ((pword) (v)+1))
 
-extern	void	prs_area_init	PARAMS(( unsigned long ));
-extern	void	alc_rst		PARAMS(( void ));
-extern	int	is_double	PARAMS(( double *, pword ));
-extern	pword	mk_term		PARAMS(( long ));
-extern	pword	mk_functor	PARAMS(( long, long ));
-extern	pword	mk_list		PARAMS(( pword, pword ));
-extern	pword	mk_int		PARAMS(( long ));
-extern	pword	mk_vo		PARAMS(( long ));
-extern	pword	mk_rule		PARAMS(( long ));
-extern	pword	mk_double	PARAMS(( double ));
-extern	double	double_val	PARAMS(( pword ));
-extern	long	functor_id_of_term PARAMS(( pword ));
-extern	long	arity_of_term	PARAMS(( pword ));
-extern	pword	mk_uia		PARAMS(( char * ));
+extern	void	prs_area_init	( unsigned long );
+extern	void	alc_rst		( void );
+extern	int	is_double	( double *, pword );
+extern	pword	mk_term		( long );
+extern	pword	mk_functor	( long, long );
+extern	pword	mk_list		( pword, pword );
+extern	pword	mk_int		( long );
+extern	pword	mk_vo		( long );
+extern	pword	mk_rule		( long );
+extern	pword	mk_double	( double );
+extern	double	double_val	( pword );
+extern	long	functor_id_of_term ( pword );
+extern	long	arity_of_term	( pword );
+extern	pword	mk_uia		( char * );
 
 #endif /* ALLOC_I */

--- a/core/alsp_src/generic/alsmem.h
+++ b/core/alsp_src/generic/alsmem.h
@@ -55,9 +55,9 @@ struct am_header {
 	/* Integrity information to make sure saved state matches image */
 
 	long **integ_als_mem;		/* address of als_mem variable */
-	int (*integ_als_mem_init) PARAMS((CONST char *, long));
+	int (*integ_als_mem_init) (const char *, long);
 					/* address of als_mem_init */
-	int (*integ_w_unify) PARAMS(( PWord, int, PWord, int ));
+	int (*integ_w_unify) ( PWord, int, PWord, int );
 					/* address of w_unify */
 	char integ_version_num[128];	/* version number information */
 	char integ_processor[128];	/* name of processor */

--- a/core/alsp_src/generic/alspi.h
+++ b/core/alsp_src/generic/alspi.h
@@ -34,8 +34,6 @@ extern char executable_path[PATH_MAX];
  * Set up some macros for dealing with prototypes and other ANSI C features.
  */
 
-#define PARAMS(arglist) arglist
-
 #if defined(macintosh)
 #define ALSPI_API(X)		pascal X
 #define ALSPI_APIP(X,Y)		pascal X (*Y)
@@ -63,14 +61,14 @@ typedef long PWord;
 typedef struct {
 		const char *name;
 		int  arity;
-		int (*func) PARAMS((void));
+		int (*func) (void);
 		const char *funcname;
 } PSTRUCT;
 
 #define PI_BEGIN static PSTRUCT pi_init_array[] = {
 #define PI_DEFINE(p,a,f) {p,a,f,((char *) -1)},
-#define PI_MODULE(m) {m,-1,((int (*)PARAMS((void))) 0),((char *) -1)},
-#define PI_END {((char *) -1),-1,((int (*)PARAMS((void))) 0),((char *) -1)} };
+#define PI_MODULE(m) {m,-1,((int (*)(void)) 0),((char *) -1)},
+#define PI_END {((char *) -1),-1,((int (*)(void)) 0),((char *) -1)} };
 
 #define PI_PDEFINE(p,a,f,fn) {p,a,f,fn},
 
@@ -132,48 +130,48 @@ typedef struct {
  * Declarations for foreign interface functions - 6/15/88 - chris
  */
 
-extern	ALSPI_API(char *)	PI_forceuia	PARAMS(( PWord *, int * ));
-extern	ALSPI_API(void)	PI_getan	PARAMS(( PWord *, int *, int ));
-extern	ALSPI_API(void)	PI_getargn	PARAMS(( PWord *, int *, PWord, int ));
-extern	ALSPI_API(void)	PI_gethead	PARAMS(( PWord *, int *, PWord ));
-extern	ALSPI_API(void)	PI_gettail	PARAMS(( PWord *, int *, PWord ));
-extern	ALSPI_API(void)	PI_getdouble	PARAMS(( double *, PWord ));
-extern	ALSPI_API(void)	PI_getstruct	PARAMS(( PWord *, int *, PWord ));
-extern	ALSPI_API(char *)	PI_getsymname	PARAMS(( char *, PWord, int ));
-extern	ALSPI_API(char *)	PI_getuianame	PARAMS(( char *, PWord, int ));
-extern	ALSPI_API(void)	PI_getuiasize	PARAMS(( PWord, int * ));
-extern	ALSPI_API(void)	PI_makedouble	PARAMS(( PWord *, int *, double ));
-extern	ALSPI_API(void)	PI_makelist	PARAMS(( PWord *, int * ));
-extern	ALSPI_API(void)	PI_makestruct	PARAMS(( PWord *, int *, PWord, int ));
-extern	ALSPI_API(void)	PI_makesym	PARAMS(( PWord *, int *, const char * ));
-extern	ALSPI_API(void)	PI_makeuia	PARAMS(( PWord *, int *, const char * ));
-extern	ALSPI_API(void)	PI_allocuia	PARAMS(( PWord *, int *, int ));
-extern	ALSPI_API(int)	PI_printf	PARAMS(( const char *, ... ));
-extern	ALSPI_API(int)	PI_aprintf	PARAMS(( const char *, const char *, ... ));
-extern  ALSPI_API(int)	PI_vprintf	PARAMS(( const char *, va_list ));
-extern  ALSPI_API(int)	PI_vaprintf	PARAMS(( const char *, const char *, va_list ));
-extern	ALSPI_API(int)	PI_rungoal	PARAMS(( PWord, PWord, int ));
-extern	ALSPI_API(int)	PI_rungoal_with_update	PARAMS(( PWord, PWord *, int * ));
-extern	ALSPI_API(int)	PI_rungoal_with_update_and_catch	PARAMS(( PWord, PWord *, int *, int * ));
-extern	ALSPI_API(int)	PI_unify	PARAMS(( PWord , int, PWord , int ));
-extern	ALSPI_API(void)	PrologInit	PARAMS(( PSTRUCT * ));
-extern	ALSPI_API(void)	PI_shutdown	PARAMS(( void ));
-extern	ALSPI_API(void)	PI_toplevel	PARAMS(( void ));
-extern	ALSPI_API(int)	PI_status_toplevel	PARAMS(( int * ));
-extern	ALSPI_API(int)	PI_prolog_init	PARAMS(( int, char **));
-extern	ALSPI_API(int)	PI_startup	PARAMS(( const PI_system_setup *));
-extern	ALSPI_API(void)	PI_throw	PARAMS((PWord obj, int objt));
-extern	ALSPI_API(void)	PI_getball	PARAMS((PWord *obj, int *objt));
-extern	ALSPI_API(int)	PI_main		PARAMS((int argc, char *argv[], void (*init)(void)));
-extern	ALSPI_API(void)	PI_interrupt	PARAMS((void));
+extern	ALSPI_API(char *)	PI_forceuia	( PWord *, int * );
+extern	ALSPI_API(void)	PI_getan	( PWord *, int *, int );
+extern	ALSPI_API(void)	PI_getargn	( PWord *, int *, PWord, int );
+extern	ALSPI_API(void)	PI_gethead	( PWord *, int *, PWord );
+extern	ALSPI_API(void)	PI_gettail	( PWord *, int *, PWord );
+extern	ALSPI_API(void)	PI_getdouble	( double *, PWord );
+extern	ALSPI_API(void)	PI_getstruct	( PWord *, int *, PWord );
+extern	ALSPI_API(char *)	PI_getsymname	( char *, PWord, int );
+extern	ALSPI_API(char *)	PI_getuianame	( char *, PWord, int );
+extern	ALSPI_API(void)	PI_getuiasize	( PWord, int * );
+extern	ALSPI_API(void)	PI_makedouble	( PWord *, int *, double );
+extern	ALSPI_API(void)	PI_makelist	( PWord *, int * );
+extern	ALSPI_API(void)	PI_makestruct	( PWord *, int *, PWord, int );
+extern	ALSPI_API(void)	PI_makesym	( PWord *, int *, const char * );
+extern	ALSPI_API(void)	PI_makeuia	( PWord *, int *, const char * );
+extern	ALSPI_API(void)	PI_allocuia	( PWord *, int *, int );
+extern	ALSPI_API(int)	PI_printf	( const char *, ... );
+extern	ALSPI_API(int)	PI_aprintf	( const char *, const char *, ... );
+extern  ALSPI_API(int)	PI_vprintf	( const char *, va_list );
+extern  ALSPI_API(int)	PI_vaprintf	( const char *, const char *, va_list );
+extern	ALSPI_API(int)	PI_rungoal	( PWord, PWord, int );
+extern	ALSPI_API(int)	PI_rungoal_with_update	( PWord, PWord *, int * );
+extern	ALSPI_API(int)	PI_rungoal_with_update_and_catch	( PWord, PWord *, int *, int * );
+extern	ALSPI_API(int)	PI_unify	( PWord , int, PWord , int );
+extern	ALSPI_API(void)	PrologInit	( PSTRUCT * );
+extern	ALSPI_API(void)	PI_shutdown	( void );
+extern	ALSPI_API(void)	PI_toplevel	( void );
+extern	ALSPI_API(int)	PI_status_toplevel	( int * );
+extern	ALSPI_API(int)	PI_prolog_init	( int, char **);
+extern	ALSPI_API(int)	PI_startup	( const PI_system_setup *);
+extern	ALSPI_API(void)	PI_throw	(PWord obj, int objt);
+extern	ALSPI_API(void)	PI_getball	(PWord *obj, int *objt);
+extern	ALSPI_API(int)	PI_main		(int argc, char *argv[], void (*init)(void));
+extern	ALSPI_API(void)	PI_interrupt	(void);
 
 
 #ifdef APP_PRINTF_CALLBACK
 extern	ALSPI_API(void)	PI_set_app_printf_callback(void (*callback)(int, va_list));
 #endif
-extern	ALSPI_API(void)	PI_app_printf	PARAMS(( int, ... ));
-extern  ALSPI_API(void)    PI_vapp_printf  PARAMS(( int, va_list ));
-extern	ALSPI_API(const char *)	PI_get_options	PARAMS(( void ));
+extern	ALSPI_API(void)	PI_app_printf	( int, ... );
+extern  ALSPI_API(void)    PI_vapp_printf  ( int, va_list );
+extern	ALSPI_API(const char *)	PI_get_options	( void );
 
 typedef long (*console_func)(char *, long);
 
@@ -183,7 +181,7 @@ extern ALSPI_API(void)	PI_set_console_functions(console_func readf,
 #ifdef macintosh
 extern	long	yield_interval;
 extern  long	yield_counter;
-extern	void	PI_yield_time	PARAMS(( void ));
+extern	void	PI_yield_time	( void );
 extern	ALSPI_API(void)	PI_set_yield_proc(void (*p)(void));
 #endif
 
@@ -351,10 +349,10 @@ typedef struct {
  * interface generator ).
  *-----------------------------------------------------------------------*/
 
-extern	ALSPI_API(int)	sym_insert_2long PARAMS(( char *, int, long, long ));
-extern	ALSPI_API(int)	sym_insert_dbl	PARAMS(( char *, int, double ));
-extern	ALSPI_API(int)	CI_get_integer	PARAMS(( PWord *, int ));
-extern	ALSPI_API(int)	CI_get_double	PARAMS(( double *, unsigned long, unsigned long ));
+extern	ALSPI_API(int)	sym_insert_2long ( char *, int, long, long );
+extern	ALSPI_API(int)	sym_insert_dbl	( char *, int, double );
+extern	ALSPI_API(int)	CI_get_integer	( PWord *, int );
+extern	ALSPI_API(int)	CI_get_double	( double *, unsigned long, unsigned long );
 
 extern	ALSPI_API(const char *) find_callback(void *func, void *object);
 

--- a/core/alsp_src/generic/arith.c
+++ b/core/alsp_src/generic/arith.c
@@ -49,19 +49,19 @@
 
 #include "random.h"
 
-extern	double	als_random	PARAMS(( void ));
+extern	double	als_random	( void );
 #ifndef HAVE_AINT
-extern	double	aint		PARAMS(( double ));
+extern	double	aint		( double );
 #endif
 /*****
 #ifndef HAVE_RINT
-extern	double	rint		PARAMS(( double ));
+extern	double	rint		( double );
 #endif
 ****/
 #ifndef HAVE_EXP10
-extern	double	exp10		PARAMS(( double ));
+extern	double	exp10		( double );
 #endif
-static	double	do_is		PARAMS(( PWord, int, int * ));
+static	double	do_is		( PWord, int, int * );
 
 static jmp_buf is_error;
 
@@ -83,14 +83,14 @@ PWord error_functor; int error_arity;
 #ifdef HAVE_SRAND48
 #define drandom drand48
 #define srandom srand48
-extern	void	srand48		PARAMS(( long ));
-extern	double	drand48		PARAMS(( void ));
+extern	void	srand48		( long );
+extern	double	drand48		( void );
 
 #elif defined(HAVE_SRANDOM)
 #define RANDRANGE 0x7fffffff
 #ifndef __DJGPP__
-extern	long	random		PARAMS(( void ));
-extern	void	srandom		PARAMS(( int ));
+extern	long	random		( void );
+extern	void	srandom		( int );
 #endif
 
 #elif defined(HAVE_SRAND)
@@ -727,7 +727,7 @@ NUMCOMP(pbi_arithnotequal, !=)
 
 
 
-int pbi_fpconst_val	PARAMS(( void ));
+int pbi_fpconst_val	( void );
 
 int
 pbi_fpconst_val()
@@ -753,7 +753,7 @@ pbi_fpconst_val()
 		FAIL;
 }
 
-int pbi_uia_poke_fpconst 	PARAMS (( void ));
+int pbi_uia_poke_fpconst 	( void );
 
 int
 pbi_uia_poke_fpconst()

--- a/core/alsp_src/generic/bcurl.c
+++ b/core/alsp_src/generic/bcurl.c
@@ -26,8 +26,8 @@
 #define PI_DOUBLE       6
 */
 
-int	curl_c_builtin	PARAMS(( void ));
-int	lookup_opt_info	PARAMS(( void ));
+int	curl_c_builtin	( void );
+int	lookup_opt_info	( void );
 char* 	normalize_opt(char* option_str);
 char* normalize_info(char* option_str);
 int lookup_code(const char *opt_name);

--- a/core/alsp_src/generic/bdb.c
+++ b/core/alsp_src/generic/bdb.c
@@ -102,7 +102,7 @@ pbi_abolish_clausegroup()
 }
 
 extern long *aib_clause_addr;
-static	int	doassert	PARAMS(( int, PWord, pword, int ));
+static	int	doassert	( int, PWord, pword, int );
 
 int
 pbi_asserta()

--- a/core/alsp_src/generic/bio.c
+++ b/core/alsp_src/generic/bio.c
@@ -65,7 +65,7 @@ pbi_save_state_to_file()		/* save_state_to_file */
 }
 #endif /* !defined(KERNAL) && !defined(PURE_ANSI) */
 
-static	int	pload_file	PARAMS(( UCHAR *, int ));
+static	int	pload_file	( UCHAR *, int );
 
 static int
 pload_file(name, reconbit)

--- a/core/alsp_src/generic/bmeta.c
+++ b/core/alsp_src/generic/bmeta.c
@@ -212,11 +212,11 @@ pbi_mangle()
 
 }
 
-extern void	disp_heap_item	PARAMS(( PWord * ));
+extern void	disp_heap_item	( PWord * );
 
 #ifdef TRAILVALS
 
-int trailed_mangle0	PARAMS((PWord,PWord,int,PWord,int));
+int trailed_mangle0	(PWord,PWord,int,PWord,int);
 
 int
 pbi_trailed_mangle(void)

--- a/core/alsp_src/generic/bmisc.c
+++ b/core/alsp_src/generic/bmisc.c
@@ -20,8 +20,8 @@
 #include <stdio.h>
 #include <time.h>
 
-static	unsigned long hashN	PARAMS(( PWord, int, int ));
-static	void	als_gensym	PARAMS(( UCHAR *, UCHAR * ));
+static	unsigned long hashN	( PWord, int, int );
+static	void	als_gensym	( UCHAR *, UCHAR * );
 
 #ifdef CMeta
 

--- a/core/alsp_src/generic/bparser.c
+++ b/core/alsp_src/generic/bparser.c
@@ -15,8 +15,8 @@
  *=============================================================================*/
 #include "defs.h"
 
-static	int	string_to_number PARAMS(( UCHAR *, double * ));
-static	int	get_prec	PARAMS(( PWord, PWord ));
+static	int	string_to_number ( UCHAR *, double * );
+static	int	get_prec	( PWord, PWord );
 
 /*
  * string_to_number is used by pbi_name to convert a potential string
@@ -1057,7 +1057,7 @@ enum C_list_codes {
     C_list_code
 };
 
-static int string_to_C_list PARAMS(( PWord *, int *, UCHAR *, enum C_list_codes ));
+static int string_to_C_list ( PWord *, int *, UCHAR *, enum C_list_codes );
 
 static int
 string_to_C_list(vp,tp,str,C_which)
@@ -1101,7 +1101,7 @@ enum ltos_retcodes {
     ltos_SUCCESS
 };
 
-static enum ltos_retcodes C_list_to_string PARAMS(( PWord *, int *, PWord, int, enum C_list_codes ));
+static enum ltos_retcodes C_list_to_string ( PWord *, int *, PWord, int, enum C_list_codes );
 
 static enum ltos_retcodes
 C_list_to_string(vp,tp,vin,tin,C_which)
@@ -1353,7 +1353,7 @@ pbi_eq_sut_int()
 	    FAIL;
 }
 
-extern void    w_mk_sut_int PARAMS(( PWord *, int *, long ));
+extern void    w_mk_sut_int ( PWord *, int *, long );
 
 void
 w_mk_sut_int(rval, rtag, ival)

--- a/core/alsp_src/generic/bsio.c
+++ b/core/alsp_src/generic/bsio.c
@@ -91,11 +91,11 @@
 /* These should be in sys/ipc.h or sys/msg.h, but some systems have really
  * lame include files.
  */
-extern	key_t	ftok		PARAMS(( CONST char *, int ));
-extern	int	msgget		PARAMS(( key_t, int ));
-extern	int	msgsnd		PARAMS(( int, CONST void *, size_t, int ));
-extern	int	msgrcv		PARAMS(( int, void *, size_t, long, int ));
-extern	int	msgctl		PARAMS(( int, int, ... ));
+extern	key_t	ftok		( const char *, int );
+extern	int	msgget		( key_t, int );
+extern	int	msgsnd		( int, const void *, size_t, int );
+extern	int	msgrcv		( int, void *, size_t, long, int );
+extern	int	msgctl		( int, int, ... );
 
 #endif /* SysVIPC */
 
@@ -217,28 +217,28 @@ extern	int	msgctl		PARAMS(( int, int, ... ));
 #include "bsio.h"
 #include "newsiolex.h"
 
-static	UCHAR *	get_stream_buffer PARAMS(( PWord, int ));
-static	void	incr_fdrefcnt	PARAMS(( int ));
-static	int	decr_fdrefcnt	PARAMS(( int ));
-static	int	compute_flags	PARAMS(( char *, int , int ));
+static	UCHAR *	get_stream_buffer ( PWord, int );
+static	void	incr_fdrefcnt	( int );
+static	int	decr_fdrefcnt	( int );
+static	int	compute_flags	( char *, int , int );
 #ifdef HAVE_SOCKET
-static	void	delete_stream_name PARAMS(( PWord ));
-static	int	accept_connection PARAMS(( PWord, char * , char **));
+static	void	delete_stream_name ( PWord );
+static	int	accept_connection ( PWord, char * , char **);
 #endif
-static	int	stream_is_ready	PARAMS(( char *, long ));
-static	void	shift_buffer	PARAMS(( UCHAR * ));
-static	int	write_buf	PARAMS(( PWord, UCHAR * ));
-static	long	stream_end	PARAMS(( UCHAR * ));
-static	int	skip_layout	PARAMS(( UCHAR * ));
-static	int	octal		PARAMS(( UCHAR ** ));
-static	unsigned long	hexadecimal	PARAMS(( UCHAR ** ));
-static	int	decimal		PARAMS(( UCHAR **, UCHAR *, double *, int *));
-static	int	escaped_char	PARAMS(( UCHAR ** ));
-static	void	quoted_atom	PARAMS(( PWord *, PWord *, int *, UCHAR **, UCHAR *lim, UCHAR *buf));
-static	int	quoted_string	PARAMS(( PWord *, PWord *, int *, UCHAR **, UCHAR *, UCHAR * ));
-static	int	char_constant	PARAMS(( UCHAR **, UCHAR *, int, int ));
-static	int	next_token0	PARAMS(( UCHAR *, PWord *, int *, PWord *, int * ));
-static	int	format_type	PARAMS(( UCHAR * ));
+static	int	stream_is_ready	( char *, long );
+static	void	shift_buffer	( UCHAR * );
+static	int	write_buf	( PWord, UCHAR * );
+static	long	stream_end	( UCHAR * );
+static	int	skip_layout	( UCHAR * );
+static	int	octal		( UCHAR ** );
+static	unsigned long	hexadecimal	( UCHAR ** );
+static	int	decimal		( UCHAR **, UCHAR *, double *, int *);
+static	int	escaped_char	( UCHAR ** );
+static	void	quoted_atom	( PWord *, PWord *, int *, UCHAR **, UCHAR *lim, UCHAR *buf);
+static	int	quoted_string	( PWord *, PWord *, int *, UCHAR **, UCHAR *, UCHAR * );
+static	int	char_constant	( UCHAR **, UCHAR *, int, int );
+static	int	next_token0	( UCHAR *, PWord *, int *, PWord *, int * );
+static	int	format_type	( UCHAR * );
 
 enum {CONSOLE_READ, CONSOLE_WRITE, CONSOLE_ERROR};
 
@@ -2998,7 +2998,7 @@ sio_simple_select()
  * sio_poll(Stream, WaitTime)
  */
 
-extern	int	get_number	PARAMS( (PWord, int, double *) );
+extern	int	get_number	(PWord, int, double *);
 
 int
 sio_poll()
@@ -4163,7 +4163,7 @@ sio_seek()
  *
  */
 
-static int scan_eoln(CONST char *cs, int eoln_type)
+static int scan_eoln(const char *cs, int eoln_type)
 {
     int len;
     
@@ -5624,9 +5624,9 @@ sio_get_number()
  * get_eoln_str() returns a pointer to a string containing the end-of-line characters for
  * the stream.
  */
-static CONST char *get_eoln_str(UCHAR *buf)
+static const char *get_eoln_str(UCHAR *buf)
 {
-    CONST char *eoln_str;
+    const char *eoln_str;
     
     switch(SIO_EOLNTYPE(buf) & SIOEOLN_WRITE_MASK) {
     case SIOEOLN_WRITE_CRLF:
@@ -6431,7 +6431,7 @@ sio_nl(void)
     PWord v1;
     int   t1;
     UCHAR *buf, *b, *l;
-    CONST UCHAR *s, *eoln_str;
+    const UCHAR *s, *eoln_str;
 
     w_get_An(&v1, &t1, 1);
 

--- a/core/alsp_src/generic/bsystem.c
+++ b/core/alsp_src/generic/bsystem.c
@@ -22,7 +22,7 @@
 #include <Types.h>
 #endif
 
-static	void	abortmessage	PARAMS(( void ));
+static	void	abortmessage	( void );
 
 int
 pbi_ouch()

--- a/core/alsp_src/generic/built.c
+++ b/core/alsp_src/generic/built.c
@@ -69,94 +69,94 @@ extern
 #endif /* arch_i386 */
 
 #ifdef MotorolaMath
-extern	int	padd		PARAMS(( void ));
-extern	int	psub		PARAMS(( void ));
-extern	int	pmul		PARAMS(( void ));
-extern	int	pdiv		PARAMS(( void ));
-extern	int	pmac		PARAMS(( void ));
-extern	int	eiexp		PARAMS(( void ));
+extern	int	padd		( void );
+extern	int	psub		( void );
+extern	int	pmul		( void );
+extern	int	pdiv		( void );
+extern	int	pmac		( void );
+extern	int	eiexp		( void );
 
-extern	int	psin		PARAMS(( void ));
-extern	int	pcos		PARAMS(( void ));
-extern	int	ptan		PARAMS(( void ));
-extern	int	psinh		PARAMS(( void ));
-extern	int	pcosh		PARAMS(( void ));
-extern	int	ptanh		PARAMS(( void ));
-extern	int	pasin		PARAMS(( void ));
-extern	int	pacos		PARAMS(( void ));
-extern	int	patan		PARAMS(( void ));
-extern	int	plog10		PARAMS(( void ));
-extern	int	plog		PARAMS(( void ));
-extern	int	pexp		PARAMS(( void ));
-extern	int	psqrt		PARAMS(( void ));
-extern	int	pfloor		PARAMS(( void ));
-extern	int	pceil		PARAMS(( void ));
-extern	int	pfabs		PARAMS(( void ));
-extern	int	pgamma		PARAMS(( void ));
-extern	int	ppow		PARAMS(( void ));
-extern	int	pfmod		PARAMS(( void ));
-extern	int	patan2		PARAMS(( void ));
-extern	int	phypot		PARAMS(( void ));
-extern	int	perf		PARAMS(( void ));
-extern	int	perfc		PARAMS(( void ));
+extern	int	psin		( void );
+extern	int	pcos		( void );
+extern	int	ptan		( void );
+extern	int	psinh		( void );
+extern	int	pcosh		( void );
+extern	int	ptanh		( void );
+extern	int	pasin		( void );
+extern	int	pacos		( void );
+extern	int	patan		( void );
+extern	int	plog10		( void );
+extern	int	plog		( void );
+extern	int	pexp		( void );
+extern	int	psqrt		( void );
+extern	int	pfloor		( void );
+extern	int	pceil		( void );
+extern	int	pfabs		( void );
+extern	int	pgamma		( void );
+extern	int	ppow		( void );
+extern	int	pfmod		( void );
+extern	int	patan2		( void );
+extern	int	phypot		( void );
+extern	int	perf		( void );
+extern	int	perfc		( void );
 
-extern	int	pc_add		PARAMS(( void ));
-extern	int	pc_sub		PARAMS(( void ));
-extern	int	pc_mul		PARAMS(( void ));
-extern	int	pcj_mul		PARAMS(( void ));
-extern	int	pc_mac		PARAMS(( void ));
-extern	int	pc_mag2		PARAMS(( void ));
-extern	int	pc_mag		PARAMS(( void ));
-extern	int	pc_conj		PARAMS(( void ));
-extern	int	pc_rec		PARAMS(( void ));
-extern	int	pc_div		PARAMS(( void ));
-extern	int	prc_mul		PARAMS(( void ));
-extern	int	prc_mac		PARAMS(( void ));
+extern	int	pc_add		( void );
+extern	int	pc_sub		( void );
+extern	int	pc_mul		( void );
+extern	int	pcj_mul		( void );
+extern	int	pc_mac		( void );
+extern	int	pc_mag2		( void );
+extern	int	pc_mag		( void );
+extern	int	pc_conj		( void );
+extern	int	pc_rec		( void );
+extern	int	pc_div		( void );
+extern	int	prc_mul		( void );
+extern	int	prc_mac		( void );
 
-extern	int	make_vector	PARAMS(( void ));
-extern	int	vrr_add		PARAMS(( void ));
-extern	int	vrr_sub		PARAMS(( void ));
-extern	int	vrr_mul		PARAMS(( void ));
-extern	int	vrr_div		PARAMS(( void ));
-extern	int	vrr_dot		PARAMS(( void ));
+extern	int	make_vector	( void );
+extern	int	vrr_add		( void );
+extern	int	vrr_sub		( void );
+extern	int	vrr_mul		( void );
+extern	int	vrr_div		( void );
+extern	int	vrr_dot		( void );
 
-extern	int	varg		PARAMS(( void ));
-extern	int	varg_first	PARAMS(( void ));
-extern	int	varg_last	PARAMS(( void ));
-extern	int	vlength		PARAMS(( void ));
+extern	int	varg		( void );
+extern	int	varg_first	( void );
+extern	int	varg_last	( void );
+extern	int	vlength		( void );
 
-extern	int	vr_sum		PARAMS(( void ));
-extern	int	vrs_scale	PARAMS(( void ));
-extern	int	vr_mag2		PARAMS(( void ));
-extern	int	vr_neg		PARAMS(( void ));
-extern	int	vrsr_mul	PARAMS(( void ));
-extern	int	vr_select	PARAMS(( void ));
+extern	int	vr_sum		( void );
+extern	int	vrs_scale	( void );
+extern	int	vr_mag2		( void );
+extern	int	vr_neg		( void );
+extern	int	vrsr_mul	( void );
+extern	int	vr_select	( void );
 
-extern	int	vcc_add		PARAMS(( void ));
-extern	int	vcc_sub		PARAMS(( void ));
-extern	int	vcc_mul		PARAMS(( void ));
-extern	int	vcc_div		PARAMS(( void ));
-extern	int	vcc_dot		PARAMS(( void ));
-extern	int	vrc_mul		PARAMS(( void ));
-extern	int	vcjc_dot	PARAMS(( void ));
-extern	int	vc_conj		PARAMS(( void ));
-extern	int	vc_neg		PARAMS(( void ));
-extern	int	vc_sum		PARAMS(( void ));
-extern	int	vcsc_mul	PARAMS(( void ));
-extern	int	vcsr_mul	PARAMS(( void ));
+extern	int	vcc_add		( void );
+extern	int	vcc_sub		( void );
+extern	int	vcc_mul		( void );
+extern	int	vcc_div		( void );
+extern	int	vcc_dot		( void );
+extern	int	vrc_mul		( void );
+extern	int	vcjc_dot	( void );
+extern	int	vc_conj		( void );
+extern	int	vc_neg		( void );
+extern	int	vc_sum		( void );
+extern	int	vcsc_mul	( void );
+extern	int	vcsr_mul	( void );
 
-extern	int	vc_cmag2	PARAMS(( void ));
-extern	int	vrc_mul		PARAMS(( void ));
+extern	int	vc_cmag2	( void );
+extern	int	vrc_mul		( void );
 
-extern	int	vc_select	PARAMS(( void ));
+extern	int	vc_select	( void );
 
-extern	int	lrr_dot		PARAMS(( void ));
-extern	int	lrr_mul		PARAMS(( void ));
-extern	int	lcc_dot		PARAMS(( void ));
-extern	int	lcc_add		PARAMS(( void ));
-extern	int	lcc_sub		PARAMS(( void ));
-extern	int	lcc_mul		PARAMS(( void ));
-extern	int	lsplit2		PARAMS(( void ));
+extern	int	lrr_dot		( void );
+extern	int	lrr_mul		( void );
+extern	int	lcc_dot		( void );
+extern	int	lcc_add		( void );
+extern	int	lcc_sub		( void );
+extern	int	lcc_mul		( void );
+extern	int	lsplit2		( void );
 
 #endif /* MotorolaMath */
 
@@ -165,7 +165,7 @@ extern	int	lsplit2		PARAMS(( void ));
 static struct blt_struct {
     const char *name;
     int   arity;
-    int   (*blt) PARAMS(( void ));
+    int   (*blt) ( void );
     const char *bltname;
 } blt_tab[] = {
 	BLT("<", 2, pbi_less, "_pbi_less"),
@@ -605,10 +605,10 @@ static struct blt_struct {
 };
 	/* blt_tab[] */
 
-#define NULLF ((int (*) PARAMS(( void ))) 0)
+#define NULLF ((int (*) ( void )) 0)
 #define BLT2(nam,arity,installer,p1,p2,fname) 				\
 		{nam,arity, 						\
-		(void (*) PARAMS((ntbl_entry *, PWord, PWord)))installer, \
+		(void (*) (ntbl_entry *, PWord, PWord))installer, \
 		p1,p2,fname}
 
 /*
@@ -616,50 +616,50 @@ static struct blt_struct {
  *      functions.
  */
 
-extern int wm_catch22 	PARAMS(( void ));
-extern int wm_colon 	PARAMS(( void ));
-extern int wm_cut 	PARAMS(( void ));
-extern int wm_jump 	PARAMS(( void ));
-extern int wm_ocall 	PARAMS(( void ));
-extern int wm_dbg_call 	PARAMS(( void ));
-extern int wm_throw 	PARAMS(( void ));
+extern int wm_catch22 	( void );
+extern int wm_colon 	( void );
+extern int wm_cut 	( void );
+extern int wm_jump 	( void );
+extern int wm_ocall 	( void );
+extern int wm_dbg_call 	( void );
+extern int wm_throw 	( void );
 
 #ifndef CMeta
-extern int wm_arg 	PARAMS(( void ));
-extern int wm_atom 	PARAMS(( void ));
-extern int wm_atomic 	PARAMS(( void ));
-extern int wm_compare 	PARAMS(( void ));
-extern int wm_float 	PARAMS(( void ));
-extern int wm_functor 	PARAMS(( void ));
-extern int wm_identical PARAMS(( void ));
-extern int wm_integer 	PARAMS(( void ));
-extern int wm_mangle 	PARAMS(( void ));
-extern int wm_nonidentical PARAMS(( void ));
-extern int wm_nonvar 	PARAMS(( void ));
-extern int wm_number 	PARAMS(( void ));
-extern int wm_var 	PARAMS(( void ));
+extern int wm_arg 	( void );
+extern int wm_atom 	( void );
+extern int wm_atomic 	( void );
+extern int wm_compare 	( void );
+extern int wm_float 	( void );
+extern int wm_functor 	( void );
+extern int wm_identical ( void );
+extern int wm_integer 	( void );
+extern int wm_mangle 	( void );
+extern int wm_nonidentical ( void );
+extern int wm_nonvar 	( void );
+extern int wm_number 	( void );
+extern int wm_var 	( void );
 
-extern int wm_call 	PARAMS(( void ));
-extern int wm_eq 	PARAMS(( void ));
-extern int wm_noneq 	PARAMS(( void ));
+extern int wm_call 	( void );
+extern int wm_eq 	( void );
+extern int wm_noneq 	( void );
 
 #endif /* CMeta */
 
 #ifdef Portable
-#define INTF(v) ((int (*) PARAMS((void))) (v))
+#define INTF(v) ((int (*) (void)) (v))
 #endif
 
 #ifdef SIO_ASM
-extern	int	wm_sio_pbyte	PARAMS(( void ));
-extern	int	wm_sio_gbyte	PARAMS(( void ));
+extern	int	wm_sio_pbyte	( void );
+extern	int	wm_sio_gbyte	( void );
 #endif /* SIO_ASM */
 
 
 static struct blt2_struct {
     const char *name;
     int   arity;
-    void  (*installer) PARAMS(( ntbl_entry *, PWord, PWord ));
-    int   (*p1) PARAMS(( void )), (*p2) PARAMS(( void ));
+    void  (*installer) ( ntbl_entry *, PWord, PWord );
+    int   (*p1) ( void ), (*p2) ( void );
     const char *bltname;
 } blt2_tab[] = {
 

--- a/core/alsp_src/generic/built.h
+++ b/core/alsp_src/generic/built.h
@@ -75,366 +75,366 @@
 	} while (0)
 
 /* bparser.c */
-extern	int	get_number	PARAMS( (PWord, int, double *) );
+extern	int	get_number	(PWord, int, double *);
 
 /* butil.c */
-extern	void	heap_copy		PARAMS( (PWord *, int *, pword) );
-extern	int	xform_uia			PARAMS( (PWord *, int *) );
-extern	int	force_uia			PARAMS( (PWord *, int *) );
-extern	void	string_to_list	PARAMS( (PWord *, int *, UCHAR *) );
-extern	int	list_to_string		PARAMS( (UCHAR *, PWord, int) );
-extern	int	getstring			PARAMS( (UCHAR **, PWord, int) );
-extern	int	getlong				PARAMS( (long *, PWord, int) );
-extern	int	get_gv_number		PARAMS( (UCHAR *) );
-extern	void set_prolog_error	PARAMS( (PWord, int, PWord, int, PWord, PWord, int, PWord, int) );
-extern	int	getdouble			PARAMS( (double *, PWord, int) );
+extern	void	heap_copy		(PWord *, int *, pword);
+extern	int	xform_uia			(PWord *, int *);
+extern	int	force_uia			(PWord *, int *);
+extern	void	string_to_list	(PWord *, int *, UCHAR *);
+extern	int	list_to_string		(UCHAR *, PWord, int);
+extern	int	getstring			(UCHAR **, PWord, int);
+extern	int	getlong				(long *, PWord, int);
+extern	int	get_gv_number		(UCHAR *);
+extern	void set_prolog_error	(PWord, int, PWord, int, PWord, PWord, int, PWord, int);
+extern	int	getdouble			(double *, PWord, int);
 
 /* wdisp.c */
-extern	void	prolog_write	PARAMS( (PWord, int) );
-extern	void	prolog_writeq	PARAMS( (PWord, int) );
-extern	void	prolog_display	PARAMS( (PWord, int) );
+extern	void	prolog_write	(PWord, int);
+extern	void	prolog_writeq	(PWord, int);
+extern	void	prolog_display	(PWord, int);
 
 /* built.c */
-extern	void	builtin_init			PARAMS( (void) );
-extern	void	time_cut_interrupt_init	PARAMS( (void) );
-extern	int	pbi_set_interrupt_vector	PARAMS((void));
-extern  int     pbi_uncaught_interrupt 	PARAMS( (void) );
+extern	void	builtin_init			(void);
+extern	void	time_cut_interrupt_init	(void);
+extern	int	pbi_set_interrupt_vector	(void);
+extern  int     pbi_uncaught_interrupt 	(void);
 
 /* bmisc.c */
 #ifdef CMeta
-extern	int	wm_identical	PARAMS(( PWord, int, PWord, int ));
+extern	int	wm_identical	( PWord, int, PWord, int );
 #endif
 
 /* arith.c */
-extern	int	pbi_time			PARAMS(( void ));
-extern	int	pbi_less			PARAMS(( void ));
-extern	int	pbi_greater			PARAMS(( void ));
-extern	int	pbi_equalorless		PARAMS(( void ));
-extern	int	pbi_greaterorequal 	PARAMS(( void ));
-extern	int	pbi_arithequal		PARAMS(( void ));
-extern	int	pbi_arithnotequal 	PARAMS(( void ));
-extern	int	pbi_is				PARAMS(( void ));
-extern	int	pbi_srandom			PARAMS(( void ));
+extern	int	pbi_time			( void );
+extern	int	pbi_less			( void );
+extern	int	pbi_greater			( void );
+extern	int	pbi_equalorless		( void );
+extern	int	pbi_greaterorequal 	( void );
+extern	int	pbi_arithequal		( void );
+extern	int	pbi_arithnotequal 	( void );
+extern	int	pbi_is				( void );
+extern	int	pbi_srandom			( void );
 /* fpbasis.c */
-extern	int pbi_fpconst_val			PARAMS( (void) );
-extern	int pbi_uia_poke_fpconst	PARAMS( (void) );
+extern	int pbi_fpconst_val			(void);
+extern	int pbi_uia_poke_fpconst	(void);
 
 /* from bcinter.c */
 #ifdef DOS
-extern	int	pbi_c_make_farptr PARAMS(( void ));
+extern	int	pbi_c_make_farptr ( void );
 #endif
-extern	int	pbi_c_malloc		PARAMS(( void ));
-extern	int	pbi_c_free			PARAMS(( void ));
-extern	int	pbi_c_set			PARAMS(( void ));
-extern	int	pbi_c_examine		PARAMS(( void ));
+extern	int	pbi_c_malloc		( void );
+extern	int	pbi_c_free			( void );
+extern	int	pbi_c_set			( void );
+extern	int	pbi_c_examine		( void );
 
 /* bdb.c */
-extern	int	pbi_abolish				PARAMS(( void ));
-extern	int	pbi_abolish_clausegroup	PARAMS(( void ));
-extern	int	pbi_asserta				PARAMS(( void ));
-extern	int	pbi_assertz				PARAMS(( void ));
-extern	int	pbi_addclause			PARAMS(( void ));
-extern	int	pbi_execcommand			PARAMS(( void ));
-extern	int	pbi_erase				PARAMS(( void ));
-extern	int	pbi_dynamic				PARAMS(( void ));
-extern	int	pbi_icode				PARAMS(( void ));
-extern	int	pbi_index_proc			PARAMS(( void ));
-extern	int	pbi_massively_abolish_clausegroup PARAMS(( void ));
-extern	int	pbi_nextproc			PARAMS(( void ));
-extern	int	pbi_procinfo			PARAMS(( void ));
-extern	int	pbi_clauseinfo			PARAMS(( void ));
-extern	int	pbi_firstargkey			PARAMS(( void ));
-extern	int	pbi_resolve_module		PARAMS(( void ));
-extern	int	pbi_exported_proc		PARAMS(( void ));
-extern	int	pbi_next_module			PARAMS(( void ));
-extern	int	pbi_cr_mod_close		PARAMS(( void ));
-extern	int	pbi_libbreak			PARAMS(( void ));
-extern	int	pbi_listasm_clause		PARAMS(( void ));
-extern	int	pbi_listasm_ntblentry	PARAMS(( void ));
-extern	int	pbi_push_clausegroup	PARAMS(( void ));
-extern	int	pbi_pop_clausegroup		PARAMS(( void ));
-extern	int	pbi_collectcode			PARAMS(( void ));
+extern	int	pbi_abolish				( void );
+extern	int	pbi_abolish_clausegroup	( void );
+extern	int	pbi_asserta				( void );
+extern	int	pbi_assertz				( void );
+extern	int	pbi_addclause			( void );
+extern	int	pbi_execcommand			( void );
+extern	int	pbi_erase				( void );
+extern	int	pbi_dynamic				( void );
+extern	int	pbi_icode				( void );
+extern	int	pbi_index_proc			( void );
+extern	int	pbi_massively_abolish_clausegroup ( void );
+extern	int	pbi_nextproc			( void );
+extern	int	pbi_procinfo			( void );
+extern	int	pbi_clauseinfo			( void );
+extern	int	pbi_firstargkey			( void );
+extern	int	pbi_resolve_module		( void );
+extern	int	pbi_exported_proc		( void );
+extern	int	pbi_next_module			( void );
+extern	int	pbi_cr_mod_close		( void );
+extern	int	pbi_libbreak			( void );
+extern	int	pbi_listasm_clause		( void );
+extern	int	pbi_listasm_ntblentry	( void );
+extern	int	pbi_push_clausegroup	( void );
+extern	int	pbi_pop_clausegroup		( void );
+extern	int	pbi_collectcode			( void );
 
 	/* freeze.c */
-extern	int	pbi_cptx		PARAMS(( void ));
-extern	int	disp_heap		PARAMS(( void ));
-extern	int     disp_item		PARAMS((void));
-extern	int	pbi_swp_tr		PARAMS(( void ));
-extern	int	pbi_walk_cps		PARAMS(( void ));
-extern	int	pbi_delay		PARAMS(( void ));
-extern  int	pbi_is_delay_var	PARAMS(( void ));
-extern  int	pbi_kill_freeze	PARAMS(( void ));
-extern	int 	pbi_clct_tr 		PARAMS(( void ));
-extern	int 	pbi_unset_2nd 		PARAMS(( void ));
-extern	int 	pbi_del_tm_for		PARAMS(( void ));
-extern	int	pbi_bind_vars		PARAMS(( void ));
-extern	int	pbi_cptz		PARAMS(( void ));
-extern	int	x_disp_heap		PARAMS(( void ));
-extern	int	pbi_x_swp_tr		PARAMS(( void ));
+extern	int	pbi_cptx		( void );
+extern	int	disp_heap		( void );
+extern	int     disp_item		(void);
+extern	int	pbi_swp_tr		( void );
+extern	int	pbi_walk_cps		( void );
+extern	int	pbi_delay		( void );
+extern  int	pbi_is_delay_var	( void );
+extern  int	pbi_kill_freeze	( void );
+extern	int 	pbi_clct_tr 		( void );
+extern	int 	pbi_unset_2nd 		( void );
+extern	int 	pbi_del_tm_for		( void );
+extern	int	pbi_bind_vars		( void );
+extern	int	pbi_cptz		( void );
+extern	int	x_disp_heap		( void );
+extern	int	pbi_x_swp_tr		( void );
 
 #ifdef INTCONSTR
 
 	/* intaux.c */
-extern int	pbi_fuzz			PARAMS((void));
+extern int	pbi_fuzz			(void);
 
 	/* int_net.c */
-extern int  ilinknet			PARAMS((void));
-extern int reset_cstr_ctrs		PARAMS (( void ));
-extern int get_cstr_ctrs_vals	PARAMS (( void ));
-extern int set_max_iters_val	PARAMS (( void ));
-extern int run_grteq_cstrs		PARAMS (( void ));
-extern int  x_int_op			PARAMS((void));
+extern int  ilinknet			(void);
+extern int reset_cstr_ctrs		( void );
+extern int get_cstr_ctrs_vals	( void );
+extern int set_max_iters_val	( void );
+extern int run_grteq_cstrs		( void );
+extern int  x_int_op			(void);
 
 #endif /* INTCONSTR */
 
 #ifdef CONSTRDEBUG
-extern void	debugconstr		PARAMS((void));
+extern void	debugconstr		(void);
 #endif /* CONSTRDEBUG */
 
 	/* bdbg.c */
-extern	int	pbi_dbg_nospy	PARAMS(( void ));
-extern	int	pbi_dbg_spy	PARAMS(( void ));
-extern	int	pbi_dbg_spyon	PARAMS(( void ));
-extern	int	pbi_dbg_spyoff	PARAMS(( void ));
-extern	int	pbi_dbg_spying	PARAMS(( void ));
+extern	int	pbi_dbg_nospy	( void );
+extern	int	pbi_dbg_spy	( void );
+extern	int	pbi_dbg_spyon	( void );
+extern	int	pbi_dbg_spyoff	( void );
+extern	int	pbi_dbg_spying	( void );
 
 	/* bgv.c */
-extern	int	pbi_gv_alloc	PARAMS(( void ));
-extern	int	pbi_gv_free	PARAMS(( void ));
-extern	int	pbi_gv_get	PARAMS(( void ));
-extern	int	pbi_gv_set	PARAMS(( void ));
-extern	int	pbi_gv_alloc_init	PARAMS(( void ));
-extern	int	pbi_gv_isfree	PARAMS(( void ));
-extern	int	pbi_gv_maxpossible	PARAMS(( void ));
+extern	int	pbi_gv_alloc	( void );
+extern	int	pbi_gv_free	( void );
+extern	int	pbi_gv_get	( void );
+extern	int	pbi_gv_set	( void );
+extern	int	pbi_gv_alloc_init	( void );
+extern	int	pbi_gv_isfree	( void );
+extern	int	pbi_gv_maxpossible	( void );
 
 	/* bio.c */
-extern	int	pbi_display	PARAMS(( void ));
-extern	int	pbi_get	PARAMS(( void ));
-extern	int	pbi_get0	PARAMS(( void ));
-extern	int	pbi_load	PARAMS(( void ));
-extern	int	pbi_nl	PARAMS(( void ));
-extern	int	pbi_put	PARAMS(( void ));
-extern	int	pbi_read	PARAMS(( void ));
-extern	int	pbi_see	PARAMS(( void ));
-extern	int	pbi_seeing	PARAMS(( void ));
-extern	int	pbi_seen	PARAMS(( void ));
-extern	int	pbi_tell	PARAMS(( void ));
-extern	int	pbi_telling	PARAMS(( void ));
-extern	int	pbi_told	PARAMS(( void ));
-extern	int	pbi_debug	PARAMS(( void ));
-extern	int	pbi_ttyflush	PARAMS(( void ));
-extern	int	pbi_write	PARAMS(( void ));
-extern	int	pbi_writeq	PARAMS(( void ));
-extern	int	pbi_obp_open	PARAMS(( void ));
-extern	int	pbi_obp_close	PARAMS(( void ));
-extern	int	pbi_obp_load	PARAMS(( void ));
-extern	int	pbi_obp_push_stop	PARAMS(( void ));
-extern	int	pbi_obp_pop	PARAMS(( void ));
-extern	int	pbi_resource_load	PARAMS(( void ));
-extern	int	pbi_old_consult	PARAMS(( void ));
-extern	int	pbi_save_image_with_state_to_file	PARAMS(( void ));
-extern	int	pbi_attach_state_to_file	PARAMS(( void ));
-extern	int	pbi_save_state_to_file	PARAMS(( void ));
-extern	int	pbi_get_current_image	PARAMS(( void ));
+extern	int	pbi_display	( void );
+extern	int	pbi_get	( void );
+extern	int	pbi_get0	( void );
+extern	int	pbi_load	( void );
+extern	int	pbi_nl	( void );
+extern	int	pbi_put	( void );
+extern	int	pbi_read	( void );
+extern	int	pbi_see	( void );
+extern	int	pbi_seeing	( void );
+extern	int	pbi_seen	( void );
+extern	int	pbi_tell	( void );
+extern	int	pbi_telling	( void );
+extern	int	pbi_told	( void );
+extern	int	pbi_debug	( void );
+extern	int	pbi_ttyflush	( void );
+extern	int	pbi_write	( void );
+extern	int	pbi_writeq	( void );
+extern	int	pbi_obp_open	( void );
+extern	int	pbi_obp_close	( void );
+extern	int	pbi_obp_load	( void );
+extern	int	pbi_obp_push_stop	( void );
+extern	int	pbi_obp_pop	( void );
+extern	int	pbi_resource_load	( void );
+extern	int	pbi_old_consult	( void );
+extern	int	pbi_save_image_with_state_to_file	( void );
+extern	int	pbi_attach_state_to_file	( void );
+extern	int	pbi_save_state_to_file	( void );
+extern	int	pbi_get_current_image	( void );
 #ifdef MacOS
-extern  int	pbi_save_app_with_obp	PARAMS(( void ));
+extern  int	pbi_save_app_with_obp	( void );
 #endif
 #ifdef DynamicForeign
-extern	int	pbi_load_foreign	PARAMS(( void ));
+extern	int	pbi_load_foreign	( void );
 #endif /* DynamicForeign */
 
 /* bmeta.c */
 #ifdef	CMeta
-extern	int	pbi_true	PARAMS(( void ));
-extern	int	pbi_equal	PARAMS(( void ));
-extern	int	pbi_arg		PARAMS(( void ));
-extern	int	pbi_mangle	PARAMS(( void ));
+extern	int	pbi_true	( void );
+extern	int	pbi_equal	( void );
+extern	int	pbi_arg		( void );
+extern	int	pbi_mangle	( void );
 #ifdef TRAILVALS
-extern int pbi_trailed_mangle PARAMS(( void ));
+extern int pbi_trailed_mangle ( void );
 #endif
-extern	int	pbi_functor	PARAMS(( void ));
-extern	int	pbi_identical	PARAMS(( void ));
-extern	int	pbi_unidentical	PARAMS(( void ));
-extern	int	pbi_eq		PARAMS(( void ));
-extern	int	pbi_noneq	PARAMS(( void ));
-extern	int	pbi_var		PARAMS(( void ));
-extern	int	pbi_nonvar	PARAMS(( void ));
-extern	int	pbi_integer	PARAMS(( void ));
-extern	int	pbi_float	PARAMS(( void ));
-extern	int	pbi_number	PARAMS(( void ));
-extern	int	pbi_atom	PARAMS(( void ));
-extern	int	pbi_atomic	PARAMS(( void ));
-extern	int	pbi_compound	PARAMS(( void ));
+extern	int	pbi_functor	( void );
+extern	int	pbi_identical	( void );
+extern	int	pbi_unidentical	( void );
+extern	int	pbi_eq		( void );
+extern	int	pbi_noneq	( void );
+extern	int	pbi_var		( void );
+extern	int	pbi_nonvar	( void );
+extern	int	pbi_integer	( void );
+extern	int	pbi_float	( void );
+extern	int	pbi_number	( void );
+extern	int	pbi_atom	( void );
+extern	int	pbi_atomic	( void );
+extern	int	pbi_compound	( void );
 #endif	/* CMeta */
-extern	int	pbi_findterm	PARAMS(( void ));
+extern	int	pbi_findterm	( void );
 
 /* bmisc.c */
 #ifdef	CMeta
-extern	int	pbi_compare	PARAMS(( void ));
+extern	int	pbi_compare	( void );
 #endif
-extern	int	pbi_hashN	PARAMS(( void ));
-extern	int	pbi_gensym	PARAMS(( void ));
-extern	int	pbi_isgensym	PARAMS(( void ));
-extern	int	pbi_ptermaddr	PARAMS(( void ));
-extern	int	pbi_traildump	PARAMS(( void ));
-extern	int	pbi_frame_info	PARAMS(( void ));
+extern	int	pbi_hashN	( void );
+extern	int	pbi_gensym	( void );
+extern	int	pbi_isgensym	( void );
+extern	int	pbi_ptermaddr	( void );
+extern	int	pbi_traildump	( void );
+extern	int	pbi_frame_info	( void );
 
 /* bos.c */
-extern	int	pbi_access	PARAMS(( void ));
-extern	int	pbi_chdir	PARAMS(( void ));
-extern	int	pbi_getenv	PARAMS(( void ));
-extern  int     pbi_get_user_home PARAMS(( void ));
-extern	int	pbi_system	PARAMS(( void ));
-extern	int	pbi_tmpnam	PARAMS(( void ));
-extern	int	pbi_protect_bottom_stack_page	PARAMS(( void ));
-extern	int	pbi_get_image_dir_and_name	PARAMS(( void ));
+extern	int	pbi_access	( void );
+extern	int	pbi_chdir	( void );
+extern	int	pbi_getenv	( void );
+extern  int     pbi_get_user_home ( void );
+extern	int	pbi_system	( void );
+extern	int	pbi_tmpnam	( void );
+extern	int	pbi_protect_bottom_stack_page	( void );
+extern	int	pbi_get_image_dir_and_name	( void );
 extern int   argcount;
 extern char **argvector;
-extern	int pbi_command_line	PARAMS((void));
+extern	int pbi_command_line	(void);
 #if defined(UNIX) /* _XOPEN_CRYPT */
-extern	int pbi_crypt			PARAMS((void));
+extern	int pbi_crypt			(void);
 #endif
-extern	int pbi_copy_file		PARAMS((void));
+extern	int pbi_copy_file		(void);
 
 /* bparser.c */
-extern	int	pbi_op		PARAMS(( void ));
-extern	int	pbi_tokid	PARAMS(( void ));
-extern	int	pbi_name	PARAMS(( void ));
-extern	int	pbi_atom_chars	PARAMS(( void ));
-extern	int	pbi_atom_codes	PARAMS(( void ));
-extern	int	pbi_atom_length	PARAMS(( void ));
-extern	int	pbi_sub_atom	PARAMS(( void ));
-extern	int	pbi_char_code	PARAMS(( void ));
-extern	int	pbi_uia_alloc	PARAMS(( void ));
-extern	int	pbi_uia_clip	PARAMS(( void ));
-extern	int	pbi_uia_size	PARAMS(( void ));
-extern	int	pbi_uia_peek	PARAMS(( void ));
-extern	int	pbi_uia_peekb	PARAMS(( void ));
-extern	int	pbi_uia_peekw	PARAMS(( void ));
-extern	int	pbi_uia_peekl	PARAMS(( void ));
-extern	int	pbi_uia_peekd	PARAMS(( void ));
-extern	int	pbi_uia_peeks	PARAMS(( void ));
-extern	int	pbi_uia_peeks4	PARAMS(( void ));
-extern	int	pbi_uia_poke	PARAMS(( void ));
-extern	int	pbi_uia_pokeb	PARAMS(( void ));
-extern	int	pbi_uia_pokew	PARAMS(( void ));
-extern	int	pbi_uia_pokel	PARAMS(( void ));
-extern	int	pbi_uia_poked	PARAMS(( void ));
-extern	int	pbi_uia_pokes	PARAMS(( void ));
-extern	int	pbi_atom_concat	PARAMS(( void ));
+extern	int	pbi_op		( void );
+extern	int	pbi_tokid	( void );
+extern	int	pbi_name	( void );
+extern	int	pbi_atom_chars	( void );
+extern	int	pbi_atom_codes	( void );
+extern	int	pbi_atom_length	( void );
+extern	int	pbi_sub_atom	( void );
+extern	int	pbi_char_code	( void );
+extern	int	pbi_uia_alloc	( void );
+extern	int	pbi_uia_clip	( void );
+extern	int	pbi_uia_size	( void );
+extern	int	pbi_uia_peek	( void );
+extern	int	pbi_uia_peekb	( void );
+extern	int	pbi_uia_peekw	( void );
+extern	int	pbi_uia_peekl	( void );
+extern	int	pbi_uia_peekd	( void );
+extern	int	pbi_uia_peeks	( void );
+extern	int	pbi_uia_peeks4	( void );
+extern	int	pbi_uia_poke	( void );
+extern	int	pbi_uia_pokeb	( void );
+extern	int	pbi_uia_pokew	( void );
+extern	int	pbi_uia_pokel	( void );
+extern	int	pbi_uia_poked	( void );
+extern	int	pbi_uia_pokes	( void );
+extern	int	pbi_atom_concat	( void );
 
 /* bsio.c */
-extern	int	sio_mkstream	PARAMS(( void ));
-extern	int	sio_errcode	PARAMS(( void ));
-extern	int	sio_set_errcode	PARAMS(( void ));
-extern	int	sio_errno	PARAMS(( void ));
-extern	int	sio_aux	PARAMS(( void ));
-extern	int	sio_fd	PARAMS(( void ));
-extern	int	sio_cpos	PARAMS(( void ));
-extern	int	sio_lpos	PARAMS(( void ));
-extern	int	sio_buf_params	PARAMS(( void ));
-extern	int	sio_increment_bufpos	PARAMS(( void ));
-extern	int	sio_set_position	PARAMS(( void ));
-extern	int	sio_set_eof	PARAMS(( void ));
-extern	int	sio_reset_eof	PARAMS(( void ));
-extern	int	sio_file_open	PARAMS(( void ));
-extern	int	sio_console_open	PARAMS(( void ));
+extern	int	sio_mkstream	( void );
+extern	int	sio_errcode	( void );
+extern	int	sio_set_errcode	( void );
+extern	int	sio_errno	( void );
+extern	int	sio_aux	( void );
+extern	int	sio_fd	( void );
+extern	int	sio_cpos	( void );
+extern	int	sio_lpos	( void );
+extern	int	sio_buf_params	( void );
+extern	int	sio_increment_bufpos	( void );
+extern	int	sio_set_position	( void );
+extern	int	sio_set_eof	( void );
+extern	int	sio_reset_eof	( void );
+extern	int	sio_file_open	( void );
+extern	int	sio_console_open	( void );
 #ifdef SysVIPC
-extern	int	sio_sysVq_open	PARAMS(( void ));
-extern	int	pbi_ftok	PARAMS(( void ));
-extern	int	pbi_msgctl	PARAMS(( void ));
+extern	int	sio_sysVq_open	( void );
+extern	int	pbi_ftok	( void );
+extern	int	pbi_msgctl	( void );
 #endif
 #ifdef SSBQ
-extern	int	sio_ssbq_open	PARAMS(( void ));
+extern	int	sio_ssbq_open	( void );
 #endif
 #ifdef HAVE_SOCKET
-extern	int	sio_nsocket		PARAMS(( void ));
-extern	int	sio_nsocket_connect	PARAMS(( void ));
-extern	int	sio_nsocket_bind	PARAMS(( void ));
-extern	int	sio_nsocket_listen	PARAMS(( void ));
-extern	int	sio_nsocket_accept	PARAMS(( void ));
-extern	int	sio_nsocket_close	PARAMS(( void ));
-extern	int	sio_nsocket_select	PARAMS(( void ));
-extern	int	sio_nsocketpair	        PARAMS(( void ));
+extern	int	sio_nsocket		( void );
+extern	int	sio_nsocket_connect	( void );
+extern	int	sio_nsocket_bind	( void );
+extern	int	sio_nsocket_listen	( void );
+extern	int	sio_nsocket_accept	( void );
+extern	int	sio_nsocket_close	( void );
+extern	int	sio_nsocket_select	( void );
+extern	int	sio_nsocketpair	        ( void );
 
-extern	int	sio_nsocket_open	PARAMS(( void ));
+extern	int	sio_nsocket_open	( void );
 
 extern int pbi_gethostbyname(void);
 extern int pbi_gethostbyaddr(void);
 
-extern	int	sio_gethostname	PARAMS(( void ));
-extern	int	sio_socket_open	PARAMS(( void ));
-extern	int	sio_is_server_socket	PARAMS(( void ));
-extern	int	sio_accept_socket_connection	PARAMS(( void ));
-extern	int	sio_poll		PARAMS(( void ));
-extern	int	sio_simple_select		PARAMS(( void ));
+extern	int	sio_gethostname	( void );
+extern	int	sio_socket_open	( void );
+extern	int	sio_is_server_socket	( void );
+extern	int	sio_accept_socket_connection	( void );
+extern	int	sio_poll		( void );
+extern	int	sio_simple_select		( void );
 #endif /* HAVE_SOCKET */
-extern	int	sio_fork	PARAMS(( void ));
-extern	int	sio_rexec	PARAMS(( void ));
-extern	int	sio_generic_open	PARAMS(( void ));
-extern	int	sio_close	PARAMS(( void ));
+extern	int	sio_fork	( void );
+extern	int	sio_rexec	( void );
+extern	int	sio_generic_open	( void );
+extern	int	sio_close	( void );
 #ifndef SIO_ASM
-extern	int	sio_get_byte	PARAMS(( void ));
-extern	int	sio_put_byte	PARAMS(( void ));
+extern	int	sio_get_byte	( void );
+extern	int	sio_put_byte	( void );
 #endif /* SIO_ASM */
-extern	int	sio_unget_byte	PARAMS(( void ));
-extern	int	sio_getpos	PARAMS(( void ));
-extern	int	sio_seek	PARAMS(( void ));
-extern	int	sio_readbuffer	PARAMS(( void ));
-extern  int     sio_set_do_lineedit PARAMS(( void ));
-extern  int     sio_set_lineedit_prompt  PARAMS(( void ));
-extern  int     sio_set_history_file    PARAMS(( void ));
-extern  int     sio_set_no_load_prev_history    PARAMS(( void ));
-extern	int	sio_writebuffer	PARAMS(( void ));
-extern	int	sio_bufshift	PARAMS(( void ));
-extern	int	sio_next_token	PARAMS(( void ));
-extern	int	sio_next_tokens	PARAMS(( void ));
-extern	int	sio_skip_layout	PARAMS(( void ));
-extern	int	sio_linenumber	PARAMS(( void ));
-extern	int	sio_put_atom	PARAMS(( void ));
-extern	int	sio_put_number	PARAMS(( void ));
-extern	int	sio_get_number	PARAMS(( void ));
-extern	int	sio_qatom	PARAMS(( void ));
-extern	int	sio_var_to_atom	PARAMS(( void ));
-extern	int	sio_lettervar	PARAMS(( void ));
-extern	int	sio_sprintf	PARAMS(( void ));
-extern	int sio_sprintf_number PARAMS((void));
-extern	int	sio_isgraphicatom	PARAMS(( void ));
-extern	int	sio_readln	PARAMS(( void ));
-extern	int	sio_nl	PARAMS(( void ));
-extern	int	sio_position_in_line	PARAMS(( void ));
+extern	int	sio_unget_byte	( void );
+extern	int	sio_getpos	( void );
+extern	int	sio_seek	( void );
+extern	int	sio_readbuffer	( void );
+extern  int     sio_set_do_lineedit ( void );
+extern  int     sio_set_lineedit_prompt  ( void );
+extern  int     sio_set_history_file    ( void );
+extern  int     sio_set_no_load_prev_history    ( void );
+extern	int	sio_writebuffer	( void );
+extern	int	sio_bufshift	( void );
+extern	int	sio_next_token	( void );
+extern	int	sio_next_tokens	( void );
+extern	int	sio_skip_layout	( void );
+extern	int	sio_linenumber	( void );
+extern	int	sio_put_atom	( void );
+extern	int	sio_put_number	( void );
+extern	int	sio_get_number	( void );
+extern	int	sio_qatom	( void );
+extern	int	sio_var_to_atom	( void );
+extern	int	sio_lettervar	( void );
+extern	int	sio_sprintf	( void );
+extern	int sio_sprintf_number (void);
+extern	int	sio_isgraphicatom	( void );
+extern	int	sio_readln	( void );
+extern	int	sio_nl	( void );
+extern	int	sio_position_in_line	( void );
 
 /* bsystem.c */
-extern	int	pbi_ouch		PARAMS(( void ));
-extern	int	pbi_forceCtlC		PARAMS(( void ));
-extern	int	pbi_forcePrologError	PARAMS(( void ));
-extern	int	pbi_reset_wm_normal	PARAMS(( void ));
-extern	int	pbi_showanswers		PARAMS(( void ));
-extern	int	pbi_halt		PARAMS(( void ));
-extern	int	pbi_statistics		PARAMS(( void ));
-extern	int	pbi_stack_overflow	PARAMS(( void ));
-extern	int	pbi_stack_info		PARAMS(( void ));
+extern	int	pbi_ouch		( void );
+extern	int	pbi_forceCtlC		( void );
+extern	int	pbi_forcePrologError	( void );
+extern	int	pbi_reset_wm_normal	( void );
+extern	int	pbi_showanswers		( void );
+extern	int	pbi_halt		( void );
+extern	int	pbi_statistics		( void );
+extern	int	pbi_stack_overflow	( void );
+extern	int	pbi_stack_info		( void );
 #ifdef MacOS
-extern	int	pbi_debugger		PARAMS(( void ));
+extern	int	pbi_debugger		( void );
 #endif
-extern	int	pbi_printno		PARAMS(( void ));
-extern	int	pbi_printwarning	PARAMS(( void ));
-/* extern	int pbi_limits_info		PARAMS(( void )); */
+extern	int	pbi_printno		( void );
+extern	int	pbi_printwarning	( void );
+/* extern	int pbi_limits_info		( void ); */
 #if	defined(Portable) && defined(IProfile)
-extern	int	pbi_init_iprofile	PARAMS(( void ));
-extern	int	pbi_dump_iprofile	PARAMS(( void ));
+extern	int	pbi_init_iprofile	( void );
+extern	int	pbi_dump_iprofile	( void );
 #endif	/* defined(Portable) && defined(IProfile) */
 
 /* gc.c */
-extern	int	gc		PARAMS(( void ));
+extern	int	gc		( void );
 
 /* sig.c */
-extern	int	pbi_alarm	PARAMS(( void ));
-extern	int	pbi_signal_name	PARAMS(( void ));
+extern	int	pbi_alarm	( void );
+extern	int	pbi_signal_name	( void );
 
 /* wam.c -- byte only */
 #ifdef TRACEBWAM
-extern	int 	toggle_bwam 	PARAMS( ( void ) );
+extern	int 	toggle_bwam 	( void );
 #endif
 
 /* lforeign.c */
@@ -442,12 +442,12 @@ extern int prolog_load_plugin(void);
 
 
 #ifdef SUBTYPES
-extern	int	pbi_less_sut_int	PARAMS(( void ));
-extern	int	pbi_eq_sut_int	PARAMS(( void ));
-extern	int	pbi_mk_sut_int	PARAMS(( void ));
-extern	int	pbi_t_sut_int	PARAMS(( void ));
-extern	int	pbi_pos_atom	PARAMS(( void ));
+extern	int	pbi_less_sut_int	( void );
+extern	int	pbi_eq_sut_int	( void );
+extern	int	pbi_mk_sut_int	( void );
+extern	int	pbi_t_sut_int	( void );
+extern	int	pbi_pos_atom	( void );
 #endif /* SUBTYPES */
 
-extern	int	curl_c_builtin	PARAMS(( void ));
-extern	int	lookup_opt_info	PARAMS(( void ));
+extern	int	curl_c_builtin	( void );
+extern	int	lookup_opt_info	( void );

--- a/core/alsp_src/generic/butil.c
+++ b/core/alsp_src/generic/butil.c
@@ -15,7 +15,7 @@
  *=====================================================================*/
 #include "defs.h"
 
-static	void	hc	PARAMS(( PWord *, int *, pword ));
+static	void	hc	( PWord *, int *, pword );
 
 /*
  * heap_copy copies structure returned by the parser to the heap

--- a/core/alsp_src/generic/cinterf.c
+++ b/core/alsp_src/generic/cinterf.c
@@ -20,14 +20,14 @@
 #include <stdio.h>
 #include "alspi.h"
 
-static	int	lookup_c_sym	PARAMS(( char * ));
-static	int	c_structinfo	PARAMS(( void ));
-static	int	c_typeinfo	PARAMS(( void ));
-static	int	c_constinfo	PARAMS(( void ));
-static	int	c_rconstinfo	PARAMS(( void ));
-static	int	c_call		PARAMS(( void ));
-static	int	c_makeuia	PARAMS(( void ));
-static	int	c_convertCstrPstr PARAMS(( void ));
+static	int	lookup_c_sym	( char * );
+static	int	c_structinfo	( void );
+static	int	c_typeinfo	( void );
+static	int	c_constinfo	( void );
+static	int	c_rconstinfo	( void );
+static	int	c_call		( void );
+static	int	c_makeuia	( void );
+static	int	c_convertCstrPstr ( void );
 
 /*
  * symbols for "$farptr", "f", "[]" and "c";
@@ -660,7 +660,7 @@ c_call()
     int   t2;			/* arglist */
     PWord vret;
     int   tret;			/* function return value */
-    int   (*funcptr) PARAMS(( char *, ...));
+    int   (*funcptr) ( char *, ...);
     long  retval;
     PWord head;
     int   headtype;
@@ -673,7 +673,7 @@ c_call()
 
     if (!CI_get_integer(&v1, t1))
 	PI_FAIL;
-    funcptr = (int (*)PARAMS((char *, ...))) v1;
+    funcptr = (int (*)(char *, ...)) v1;
 
     while (t2 == PI_LIST) {
 	PI_gethead(&head, &headtype, v2);
@@ -689,7 +689,7 @@ c_call()
 
     switch (nargs) {
 	case 0:
-	    retval = (*(int (*)PARAMS((void)))funcptr) ();
+	    retval = (*(int (*)(void))funcptr) ();
 	    break;
 	case 1:
 	    retval = (*funcptr) (args[0]);

--- a/core/alsp_src/generic/compile.c
+++ b/core/alsp_src/generic/compile.c
@@ -93,40 +93,40 @@ static int cd_gmod;		/* Goal module; i.e, module to place next goal in	 */
 static int model_SP;
 static int model_E;
 
-static	int		comp_rule				PARAMS(( pword ));
-static	void	deallocate_environment	PARAMS(( pword, int, int, int ));
-static	void	initialize_environment_variables PARAMS(( void ));
+static	int		comp_rule				( pword );
+static	void	deallocate_environment	( pword, int, int, int );
+static	void	initialize_environment_variables ( void );
 #if defined(InMath) && !defined(NewMath)
-static	long	regfreemap				PARAMS(( void ));
+static	long	regfreemap				( void );
 #endif
 #ifdef NewMath
-static	long	regusemap				PARAMS(( void ));
-static	void	arith_temp_homes		PARAMS(( void ));
+static	long	regusemap				( void );
+static	void	arith_temp_homes		( void );
 #endif
-static	int		do_macro				PARAMS(( pword, int ));
-static	int		goalsize				PARAMS(( pword ));
-static	void	incr_usecnt				PARAMS(( int ));
-static	void	init_model				PARAMS(( pword, pword ));
-static	void	init_targets			PARAMS(( pword ));
-static	void	init_only_targets		PARAMS(( pword ));
-static	void	reassign_homes			PARAMS(( pword ));
-static	void	comp_head				PARAMS(( pword ));
-static	void	record_first_argument	PARAMS(( int, pword ));
-static	void	comp_head_structure		PARAMS(( int ));
-static	void	comp_hstruct_argument	PARAMS(( pword, int ));
-static	void	move					PARAMS(( int, int ));
-static	int		find_home				PARAMS(( int ));
-static	int		find_temp_in_reg		PARAMS(( int ));
-static	int		free_target				PARAMS(( int ));
-static	void	move_perms				PARAMS(( int ));
-static	void	move_to_temp			PARAMS(( int ));
-static	void	comp_goal				PARAMS(( pword ));
-static	int		comp_goal_structure		PARAMS(( pword, int ));
-static	int		comp_struct_arg1		PARAMS(( pword ));
-static	void	comp_struct_arg2		PARAMS(( pword, int, int ));
-static	pword	get_compiler_directives	PARAMS(( pword ));
-static	void	compiler_directives 	PARAMS(( void ));
-static	void	emit_cd_cutpt			PARAMS(( void ));
+static	int		do_macro				( pword, int );
+static	int		goalsize				( pword );
+static	void	incr_usecnt				( int );
+static	void	init_model				( pword, pword );
+static	void	init_targets			( pword );
+static	void	init_only_targets		( pword );
+static	void	reassign_homes			( pword );
+static	void	comp_head				( pword );
+static	void	record_first_argument	( int, pword );
+static	void	comp_head_structure		( int );
+static	void	comp_hstruct_argument	( pword, int );
+static	void	move					( int, int );
+static	int		find_home				( int );
+static	int		find_temp_in_reg		( int );
+static	int		free_target				( int );
+static	void	move_perms				( int );
+static	void	move_to_temp			( int );
+static	void	comp_goal				( pword );
+static	int		comp_goal_structure		( pword, int );
+static	int		comp_struct_arg1		( pword );
+static	void	comp_struct_arg2		( pword, int, int );
+static	pword	get_compiler_directives	( pword );
+static	void	compiler_directives 	( void );
+static	void	emit_cd_cutpt			( void );
 
 #if 0
 #ifdef MaxFunc

--- a/core/alsp_src/generic/compile.h
+++ b/core/alsp_src/generic/compile.h
@@ -280,14 +280,14 @@
 #endif
 
 /* compile.c */
-extern	int	compile_clause	PARAMS(( pword, int ));
-extern	void	gccallinfo	PARAMS(( void ));
-extern	int	index_of	PARAMS(( int ));
-extern	int	disp_of		PARAMS(( int ));
-extern	int	find_temp	PARAMS(( void ));
+extern	int	compile_clause	( pword, int );
+extern	void	gccallinfo	( void );
+extern	int	index_of	( int );
+extern	int	disp_of		( int );
+extern	int	find_temp	( void );
 #ifdef NewMath
-extern	void	comp_math_struct PARAMS(( pword ));
+extern	void	comp_math_struct ( pword );
 #endif
 
 /* compmath.c */
-extern	void	comp_math	PARAMS(( pword, int, long, long ));
+extern	void	comp_math	( pword, int, long, long );

--- a/core/alsp_src/generic/compmath.c
+++ b/core/alsp_src/generic/compmath.c
@@ -344,7 +344,7 @@ int   cmictab[] =
 
 
 
-static	void	comp_exp	PARAMS(( pword ));
+static	void	comp_exp	( pword );
 
 /*
  * comp_math is called from compile.c with four arguments.

--- a/core/alsp_src/generic/debugsys.c
+++ b/core/alsp_src/generic/debugsys.c
@@ -49,7 +49,7 @@ int debug_system[MAX_DEBUG_FEATS] = {0};
 	/*-------------------------------------------------------
 	 |	For access to debug_system[] from prolog:
 	 *------------------------------------------------------*/
-int pbi_toggle_debug_system	PARAMS(( void ));
+int pbi_toggle_debug_system	( void );
 
 int
 pbi_toggle_debug_system()
@@ -78,7 +78,7 @@ pbi_toggle_debug_system()
 	 |		GARBAGE COLLECTION ROUTINES
 	 *------------------------------------------------------*/
 
-void print_chpts PARAMS ((register long *));
+void print_chpts (register long *);
 
 void
 print_chpts(register long *b)

--- a/core/alsp_src/generic/debugsys.h
+++ b/core/alsp_src/generic/debugsys.h
@@ -42,7 +42,7 @@ typedef enum {
 
 extern int debug_system[];
 
-extern	int pbi_toggle_debug_system	PARAMS( ( void ) );
+extern	int pbi_toggle_debug_system	( void );
 
 
 #endif /* DEBUGSYS */

--- a/core/alsp_src/generic/defs.h
+++ b/core/alsp_src/generic/defs.h
@@ -213,22 +213,6 @@
 
 #endif /* PURE_ANSI */
 
-/*---------------------------------------------------------------------*
- | Set up some macros for dealing with prototypes and other ANSI C features.
- *---------------------------------------------------------------------*/
-
-#ifndef PARAMS
-#if defined(__STDC__) || defined(__cplusplus)
-#define CONST const
-#define PARAMS(arglist) arglist
-#undef OldStrs
-#else 		/* !__STDC__ */
-#define CONST
-#define PARAMS(arglist) ()
-#define OldStrs
-#endif		/* __STDC__ */
-#endif /* PARAMS */
-
 #ifdef UNIX
 			/* include some standard files */
 #include <sys/types.h>
@@ -355,17 +339,17 @@
 /*---------------------------------------------------------------------*
  | Declare the als memory allocation function and associated helpers
  *---------------------------------------------------------------------*/
-extern	int	als_mem_init	PARAMS(( CONST char *file, long offset ));
-extern	long *	ss_pmalloc	PARAMS(( size_t size, int fe_num, long *asizep ));
-extern	long *	ss_malloc	PARAMS(( size_t size, int fe_num ));
-extern	void	ss_register_global PARAMS(( long *addr ));
-extern	long	ss_image_offset	PARAMS((const char *));
-extern	int	ss_save_image_with_state PARAMS((CONST char * ));
-extern	int	ss_attach_state_to_file PARAMS((const char *file_name));
-extern	int	ss_save_state	PARAMS((CONST char *, long ));
-extern	void	protect_bottom_stack_page PARAMS(( void ));
-extern	long *	ss_fmalloc_start PARAMS(( void ));
-extern	long *	ss_fmalloc	PARAMS(( size_t ));
+extern	int	als_mem_init	( const char *file, long offset );
+extern	long *	ss_pmalloc	( size_t size, int fe_num, long *asizep );
+extern	long *	ss_malloc	( size_t size, int fe_num );
+extern	void	ss_register_global ( long *addr );
+extern	long	ss_image_offset	(const char *);
+extern	int	ss_save_image_with_state (const char * );
+extern	int	ss_attach_state_to_file (const char *file_name);
+extern	int	ss_save_state	(const char *, long );
+extern	void	protect_bottom_stack_page ( void );
+extern	long *	ss_fmalloc_start ( void );
+extern	long *	ss_fmalloc	( size_t );
 
 /*---------------------------------------------------------------------*
  | Declare prototypes of other functions which have no obvious header file.
@@ -373,8 +357,8 @@ extern	long *	ss_fmalloc	PARAMS(( size_t ));
 
 /* ----------   arith.c ----------   */
 
-void make_ieee_nan PARAMS( (PWord *, int *) );
-void make_ieee_inf PARAMS( (PWord *, int *) );
+void make_ieee_nan (PWord *, int *);
+void make_ieee_inf (PWord *, int *);
 
 /* os routines. */
 int os_copy_file(const char *from_file, const char *to_file);
@@ -393,8 +377,8 @@ extern	int	win32s_system;
 extern	int	MPW_Tool;
 #endif
 
-extern	void	als_exit	PARAMS(( int ));
-extern	void	heap_overflow	PARAMS(( void ));
+extern	void	als_exit	( int );
+extern	void	heap_overflow	( void );
 
 extern char library_path[PATH_MAX];
 extern char library_dir[PATH_MAX];
@@ -403,68 +387,68 @@ extern char executable_path[PATH_MAX];
 void	locate_library_executable(int argc, char *argv[]);
 
 /* ----------   arith.c ----------   */
-void make_ieee_nan PARAMS( (PWord *, int *) );
-void make_ieee_inf PARAMS( (PWord *, int *) );
+void make_ieee_nan (PWord *, int *);
+void make_ieee_inf (PWord *, int *);
 
 
 /* ----------   disassem.c ----------   */
-extern	void	list_asm	PARAMS(( Code *, int ));
+extern	void	list_asm	( Code *, int );
 
 /* ----------   loadfile.c ----------   */
-/* extern	void	fix_MAGIC	PARAMS(( void )); */
-extern	void	f_icode		PARAMS(( int, long, long, long, long ));
-extern	int	obp_open	PARAMS(( char * ));
-extern	void	obp_close	PARAMS(( void ));
-extern	int	f_load		PARAMS(( CONST char * ));
+/* extern	void	fix_MAGIC	( void ); */
+extern	void	f_icode		( int, long, long, long, long );
+extern	int	obp_open	( char * );
+extern	void	obp_close	( void );
+extern	int	f_load		( const char * );
 enum load_file_options { RECONSULT = 1 << 0, SUPPRESS_OBP = 1 << 1};
-extern	int	load_file	PARAMS(( char *, int ));
+extern	int	load_file	( char *, int );
 #ifdef MacOS
-extern	int	obpres_load	PARAMS((const char *fname));
+extern	int	obpres_load	(const char *fname);
 #endif
-extern	void	obp_push	PARAMS(( void ));
-extern	void	obp_pop		PARAMS(( void ));
+extern	void	obp_push	( void );
+extern	void	obp_pop		( void );
 
 /* ----------   sig.c ----------   */
-extern	void	deathwatch	PARAMS(( void ));
-extern	void	reissue_cntrlc	PARAMS(( void ));
+extern	void	deathwatch	( void );
+extern	void	reissue_cntrlc	( void );
 
 /* ----------   vprintf.c ----------   */
-extern	void	PI_oprintf	PARAMS(( const char *, ... ));
-extern	void	PI_oputchar	PARAMS(( int ));
+extern	void	PI_oprintf	( const char *, ... );
+extern	void	PI_oputchar	( int );
 
 /* ----------   fsdos.c, fsmac.c, fsunix.c, or fsvms.c ----------   */
-extern	void	init_fsutils	PARAMS(( void ));
+extern	void	init_fsutils	( void );
 
-extern	int	pgetcwd		PARAMS(( void ));
-extern	int	pchdir		PARAMS(( void ));
-extern	int	punlink		PARAMS(( void ));
+extern	int	pgetcwd		( void );
+extern	int	pchdir		( void );
+extern	int	punlink		( void );
 
 #ifdef FSACCESS
-extern	int	getDirEntries	PARAMS(( void ));
-extern	int	getFileStatus	PARAMS(( void ));
-extern	int	read_link	PARAMS(( void ));
-extern	int	make_symlink	PARAMS(( void ));
-extern	int	pcmp_fs		PARAMS(( void ));
-extern	int	prmdir		PARAMS(( void ));
-extern	int	pmkdir		PARAMS(( void ));
-extern	char *	canonical_pathname PARAMS(( char *, char ** ));
-extern	int	canonicalize_pathname PARAMS(( void ));
-extern	int	pgetpid		PARAMS(( void ));
+extern	int	getDirEntries	( void );
+extern	int	getFileStatus	( void );
+extern	int	read_link	( void );
+extern	int	make_symlink	( void );
+extern	int	pcmp_fs		( void );
+extern	int	prmdir		( void );
+extern	int	pmkdir		( void );
+extern	char *	canonical_pathname ( char *, char ** );
+extern	int	canonicalize_pathname ( void );
+extern	int	pgetpid		( void );
 #endif /* FSACCESS */
 
 #if (!defined(__DJGPP__) && !defined(__GO32__))
-extern	long	get_file_modified_time	PARAMS((CONST char * ));
-extern	int	isdir			PARAMS((CONST char * ));
+extern	long	get_file_modified_time	(const char * );
+extern	int	isdir			(const char * );
 #endif
 
 #if MacOS
-extern	int	absolute_pathname	PARAMS((CONST char *name));
-extern	char *	re_comp			PARAMS((CONST char *pattern));
-extern	int	re_exec			PARAMS((CONST char *s));
+extern	int	absolute_pathname	(const char *name);
+extern	char *	re_comp			(const char *pattern);
+extern	int	re_exec			(const char *s);
 #ifndef HAVE_GUSI
-extern  int	access			PARAMS((CONST char *, int x));
-extern  int	chdir			PARAMS((CONST char *dirname));
-extern  char *	getcwd			PARAMS((char *, int));
+extern  int	access			(const char *, int x);
+extern  int	chdir			(const char *dirname);
+extern  char *	getcwd			(char *, int);
 #endif
 #endif
 
@@ -482,34 +466,34 @@ extern long standard_console_write(char *buf, long n);
 extern long standard_console_error(char *buf, long n);
 
 /* ----------   sig.c ----------   */
-extern	void	init_sigint	PARAMS(( void ));
-extern	void	reset_sigint	PARAMS(( void ));
+extern	void	init_sigint	( void );
+extern	void	reset_sigint	( void );
 
 /* ----------   cinterf.c ----------   */
-extern	void	cinterf_init	PARAMS(( void ));
+extern	void	cinterf_init	( void );
 
 /* ----------   from either assembly code or wam.c ----------   */
-extern	void	wm_exec		PARAMS(( Code * ));
-extern	int	wm_rungoal	PARAMS(( PWord, PWord ));
+extern	void	wm_exec		( Code * );
+extern	int	wm_rungoal	( PWord, PWord );
 
 /* ----------   foreign.c ----------   */
-extern	int	load_foreign	PARAMS(( char *, char *, char * ));
+extern	int	load_foreign	( char *, char *, char * );
 
 #ifdef DynamicForeign
 /* ----------   lforeign.c ----------   */
-extern	void (*	load_object	PARAMS(( char *, char *, char * )) ) PARAMS((void));
-extern	void	foreign_shutdown PARAMS(( void ));
+extern	void (*	load_object	( char *, char *, char * ) ) (void);
+extern	void	foreign_shutdown ( void );
 #endif /* DynamicForeign */
 
 #ifdef Portable
-extern	void	wam_init	PARAMS(( void ));
+extern	void	wam_init	( void );
 #endif /* Portable */
 
 /* ----------   icode1.c ----------   */
-extern	int	init_icode_buf	PARAMS(( int ));
+extern	int	init_icode_buf	( int );
 
 #ifdef MacOS
-extern	void	init_math		PARAMS(( void ));
+extern	void	init_math		( void );
 #endif
 
 #ifdef MaxFunc

--- a/core/alsp_src/generic/expand.c
+++ b/core/alsp_src/generic/expand.c
@@ -23,13 +23,13 @@
 #include "icodegen.h"
 #include "main.h"
 
-static	void	rxpbod			PARAMS(( pword ));
-static	pword	expand_pred		PARAMS(( pword ));
-static	pword	expand_fact		PARAMS(( int, pword ));
-static	pword	expand_rule		PARAMS(( int, pword ));
-static	pword	expand_query	PARAMS(( int, pword ));
-static	pword	expand_command	PARAMS(( int, pword ));
-static  pword	expand_expand	PARAMS(( int, pword ));
+static	void	rxpbod			( pword );
+static	pword	expand_pred		( pword );
+static	pword	expand_fact		( int, pword );
+static	pword	expand_rule		( int, pword );
+static	pword	expand_query	( int, pword );
+static	pword	expand_command	( int, pword );
+static  pword	expand_expand	( int, pword );
 
 /*
  * DCG and Rule Expansion:
@@ -282,19 +282,19 @@ static long vtable[4096];
 static int vtp;
 
 
-static	pword	cvt_walk_term	PARAMS(( PWord ));
-static	pword	cvt_walk_list	PARAMS(( PWord ));
-static	pword	cvt_walk_sym	PARAMS(( PWord ));
-static	pword	cvt_walk_int	PARAMS(( PWord ));
-static	pword	cvt_walk_var	PARAMS(( PWord ));
-static	pword	cvt_walk_uia	PARAMS(( PWord ));
+static	pword	cvt_walk_term	( PWord );
+static	pword	cvt_walk_list	( PWord );
+static	pword	cvt_walk_sym	( PWord );
+static	pword	cvt_walk_int	( PWord );
+static	pword	cvt_walk_var	( PWord );
+static	pword	cvt_walk_uia	( PWord );
 
 #ifdef DoubleType
-static	pword	cvt_walk_dbl	PARAMS(( PWord ));
+static	pword	cvt_walk_dbl	( PWord );
 #endif
 
 
-static pword (*cvt_walk_tbl[])PARAMS(( PWord )) = {
+static pword (*cvt_walk_tbl[])( PWord ) = {
     	cvt_walk_var,
 	cvt_walk_list,
 	cvt_walk_term,

--- a/core/alsp_src/generic/fatal.h
+++ b/core/alsp_src/generic/fatal.h
@@ -19,7 +19,7 @@
 #ifndef _FATAL_H_INCLUDED_
 #define _FATAL_H_INCLUDED_ 1
 
-extern	void	fatal_error	PARAMS( (int, long) );
+extern	void	fatal_error	(int, long);
 
 /* all error codes moved to alspi.h */
 

--- a/core/alsp_src/generic/fileio.c
+++ b/core/alsp_src/generic/fileio.c
@@ -17,9 +17,9 @@
 
 #ifdef OLDFIO
 
-static	void	fio_nxln	PARAMS(( lxi_but * ));
-static	int	fio_syntax_err	PARAMS(( lxi_but *, const char * ));
-static	void	file_error	PARAMS(( const char * ));
+static	void	fio_nxln	( lxi_but * );
+static	int	fio_syntax_err	( lxi_but *, const char * );
+static	void	file_error	( const char * );
 
 sefldsc seetbl[MAXSEE] =
 { {
@@ -120,7 +120,7 @@ static char *univ_fgets(char *s, int n, FILE *stream)
  */
 
 #define GEN_TABS(fncname,tbl,tbmax)				\
-static int fncname PARAMS(( int ));				\
+static int fncname ( int );				\
 static int							\
 fncname(tok)							\
     int tok;							\

--- a/core/alsp_src/generic/fileio.h
+++ b/core/alsp_src/generic/fileio.h
@@ -61,15 +61,15 @@ extern pptinfo prompts[];
 #define PMPT_CONSULT 1
 #define PMPT_READ    2
 
-extern	void	fio_init	PARAMS( (void) );
-extern	int	fio_see		PARAMS( (int) );
-extern	void	fio_seen	PARAMS( (void) );
-extern	int	fio_seeing	PARAMS( (void) );
-extern	int	fio_get0	PARAMS( (void) );
-extern	int	fio_get		PARAMS( (void) );
-extern	void	fio_put		PARAMS( (int) );
-extern	void	fio_nl		PARAMS( (void) );
-extern	int	fio_tell	PARAMS( (int) );
-extern	void	fio_told	PARAMS( (void) );
-extern	int	fio_telling	PARAMS( (void) );
-extern	void	fio_flush	PARAMS( (void) );
+extern	void	fio_init	(void);
+extern	int	fio_see		(int);
+extern	void	fio_seen	(void);
+extern	int	fio_seeing	(void);
+extern	int	fio_get0	(void);
+extern	int	fio_get		(void);
+extern	void	fio_put		(int);
+extern	void	fio_nl		(void);
+extern	int	fio_tell	(int);
+extern	void	fio_told	(void);
+extern	int	fio_telling	(void);
+extern	void	fio_flush	(void);

--- a/core/alsp_src/generic/foreign.c
+++ b/core/alsp_src/generic/foreign.c
@@ -21,8 +21,8 @@
 
 #ifndef DoubleType
 
-static	void	fixTag		PARAMS(( PWord *, int * ));
-static	void	tagFix		PARAMS(( PWord *, int * ));
+static	void	fixTag		( PWord *, int * );
+static	void	tagFix		( PWord *, int * );
 
 static void
 fixTag(v, t)
@@ -59,7 +59,7 @@ load_foreign(filename, libstr, initfcn)
     char *initfcn;
 {
 #ifdef DynamicForeign
-    void (*fptr)PARAMS(( void ));
+    void (*fptr)( void );
     if ( (fptr = load_object(filename, libstr, initfcn)) ) {
 	(*fptr)();
 	return 1;

--- a/core/alsp_src/generic/fpbasis.c
+++ b/core/alsp_src/generic/fpbasis.c
@@ -10,8 +10,8 @@
 
 #include <math.h>
 
-int is_ieee_nan PARAMS( (double) );
-int is_ieee_inf PARAMS( (double) );
+int is_ieee_nan (double);
+int is_ieee_inf (double);
 
 int
 is_ieee_nan(v)

--- a/core/alsp_src/generic/fpbasis.h
+++ b/core/alsp_src/generic/fpbasis.h
@@ -11,8 +11,8 @@
 #include <ieeefp.h>
 #endif
 
-extern int is_ieee_nan PARAMS( (double) );
-extern int is_ieee_inf PARAMS( (double) );
+extern int is_ieee_nan (double);
+extern int is_ieee_inf (double);
 
 #  define D_PI      3.14159265358979323846
 #  define D_PI_2    1.57079632679489661923

--- a/core/alsp_src/generic/freeze.c
+++ b/core/alsp_src/generic/freeze.c
@@ -21,15 +21,15 @@
 #include "compile.h"
 #include "freeze.h"
 
-int	pbi_delay		PARAMS(( void ));
-int	pbi_is_delay_var	PARAMS(( void ));
-int	update_chpt_slots	PARAMS(( PWord ));
-int	pbi_clct_tr		PARAMS(( void ));
-int	pbi_unset_2nd		PARAMS(( void ));
-int 	pbi_del_tm_for		PARAMS(( void ));
-PWord	deref_2			PARAMS(( PWord ));
+int	pbi_delay		( void );
+int	pbi_is_delay_var	( void );
+int	update_chpt_slots	( PWord );
+int	pbi_clct_tr		( void );
+int	pbi_unset_2nd		( void );
+int 	pbi_del_tm_for		( void );
+PWord	deref_2			( PWord );
 
-int pbi_kill_freeze		PARAMS(( void ));
+int pbi_kill_freeze		( void );
 
 /*---------------------------------------------------------------*
  | pbi_delay()
@@ -445,10 +445,10 @@ printf("combin_dels:r=_%lu f=_%lu wm_H=%x wm_HB=%x wm_B=%x\n",
                                DEBUGGING FUNCTIONS
  *========================================================================*/
 
-int	pbi_walk_cps		PARAMS(( void ));
-void	disp_heap_item		PARAMS(( PWord * ));
-int	pbi_swp_tr		PARAMS(( void ));
-int	disp_heap 		PARAMS(( void ));
+int	pbi_walk_cps		( void );
+void	disp_heap_item		( PWord * );
+int	pbi_swp_tr		( void );
+int	disp_heap 		( void );
 
 	/*-------------------------------------------------*
 	 | Walk the choice point stack,from newest to
@@ -703,7 +703,7 @@ printf("Heap display: start = %x --> stop = %x\n",start,stop);
 }
 
 
-int disp_item	PARAMS((void));
+int disp_item	(void);
 
 int
 disp_item()
@@ -722,10 +722,10 @@ disp_item()
                                DEBUGGING FUNCTIONS_xxxx
  *========================================================================*/
 
-int	pbi_walk_cps		PARAMS(( void ));
-void	x_disp_heap_item	PARAMS(( PWord * ));
-int	pbi_x_swp_tr		PARAMS(( void ));
-int	x_disp_heap 		PARAMS(( void ));
+int	pbi_walk_cps		( void );
+void	x_disp_heap_item	( PWord * );
+int	pbi_x_swp_tr		( void );
+int	x_disp_heap 		( void );
 
 void
 x_disp_heap_item(CurT)
@@ -891,7 +891,7 @@ printf("====== Heap display_x: start = %x --> stop = %x\n",start,stop);
 
 
 /*
-int disp_item	PARAMS((void));
+int disp_item	(void);
 
 int
 disp_item()

--- a/core/alsp_src/generic/freeze.h
+++ b/core/alsp_src/generic/freeze.h
@@ -2,6 +2,6 @@
 
 #define CHK_DELAY(v) (MFUNCTOR_TOKID(*(((PWord *)v)-1)) == TK_DELAY) && (MFUNCTOR_ARITY(*(((PWord *)v)-1)) == 4)
 
-extern 	void	combin_dels PARAMS( (PWord, PWord));
+extern 	void	combin_dels (PWord, PWord);
 
 

--- a/core/alsp_src/generic/fsmac.c
+++ b/core/alsp_src/generic/fsmac.c
@@ -317,7 +317,7 @@ static int canonicalize_pathname(void)
 /* Other routines. */
 
 
-int absolute_pathname(CONST char *name)
+int absolute_pathname(const char *name)
 {    
     return *name != ':' && (strchr(name, ':') != NULL);
 }

--- a/core/alsp_src/generic/fsunix.c
+++ b/core/alsp_src/generic/fsunix.c
@@ -728,8 +728,8 @@ pmkdir()
 
 #define STAT stat_with_timeout
 
-static	void	stat_timedout		PARAMS(( void ));
-static	int	stat_with_timeout	PARAMS(( const char *, struct stat * ));
+static	void	stat_timedout		( void );
+static	int	stat_with_timeout	( const char *, struct stat * );
 
 static void
 stat_timedout()
@@ -1018,7 +1018,7 @@ canonicalize_pathname()
 
 long 
 get_file_modified_time(fname)
-    CONST char *fname;
+    const char *fname;
 {
     struct stat buf;
 
@@ -1034,7 +1034,7 @@ get_file_modified_time(fname)
  */
 int
 isdir(fname)
-    CONST char *fname;
+    const char *fname;
 {
     struct stat buf;
 

--- a/core/alsp_src/generic/gc.c
+++ b/core/alsp_src/generic/gc.c
@@ -27,11 +27,11 @@
 
 #if 0 /* RH6 */
 #if defined(HAVE_SIGACTION) && defined(SA_SIGINFO)
-extern void stack_overflow  PARAMS(( int, siginfo_t *, ucontext_t * ));
+extern void stack_overflow  ( int, siginfo_t *, ucontext_t * );
 #elif defined(HAVE_SIGVEC) || defined(HAVE_SIGVECTOR)
-extern void    stack_overflow  PARAMS(( int, int, struct sigcontext *, caddr_t ));
+extern void    stack_overflow  ( int, int, struct sigcontext *, caddr_t );
 #elif defined(Portable)
-extern void   stack_overflow  PARAMS(( int ));
+extern void   stack_overflow  ( int );
 #else
 #error
 #endif
@@ -130,15 +130,15 @@ static int gccallcount;		/* number of times gc has been called */
 extern int gcbeep;
 #endif /* ---------------------------------------------- DEBUGSYS --*/
 
-static	long *	mark_args	PARAMS(( long *, Code * ));
-static	void	mark_from	PARAMS(( long * ));
-static	void	rev		    PARAMS(( long *, long *, long *, long ));
-static	void	rev_update	PARAMS(( long *, long ));
-static	void	init_marks	PARAMS(( void ));
-static	void	mark		PARAMS(( long ));
+static	long *	mark_args	( long *, Code * );
+static	void	mark_from	( long * );
+static	void	rev		    ( long *, long *, long *, long );
+static	void	rev_update	( long *, long );
+static	void	init_marks	( void );
+static	void	mark		( long );
 
 #ifdef INTCONSTR
-static	int	core_gc		PARAMS(( void ));
+static	int	core_gc		( void );
 #endif
 
 #include <stdio.h>

--- a/core/alsp_src/generic/generate/bldtok.c
+++ b/core/alsp_src/generic/generate/bldtok.c
@@ -13,13 +13,8 @@
 #include <stdio.h>
 #include "../parser.h"
 
-#if __STDC__ || !defined(OldStrs)
 #define TK(idx,t) {#idx,t,0,0}
 #define OP(idx,t,a,p) {#idx,t,a,p}
-#else
-#define TK(idx,t) {"idx",t,0,0}
-#define OP(idx,t,a,p) {"idx",t,a,p}
-#endif
 
 struct tokini {
     char *id;

--- a/core/alsp_src/generic/icodegen.h
+++ b/core/alsp_src/generic/icodegen.h
@@ -37,48 +37,48 @@ extern ic_uptr_type ic_uptr;
 #define ic_ptr	ic_uptr.code_ptr
 
 /* icode1.c */
-extern 	void	icode		PARAMS(( int, long, long, long, long ));
+extern 	void	icode		( int, long, long, long, long );
 
 /* icode2.c */
-extern	void	ic_install_overflow_call PARAMS(( ntbl_entry * ));
-extern	void	ic_install_call_entry	PARAMS(( ntbl_entry * ));
-extern	void	ic_install_normal_exec_entry PARAMS(( ntbl_entry * ));
-extern	void	ic_install_spy		PARAMS(( ntbl_entry * ));
-extern	void	ic_install_libbreak	PARAMS(( ntbl_entry *, int ));
-extern	void	ic_install_decr_icount	PARAMS(( ntbl_entry * ));
-extern	void	ic_install_resolve_ref	PARAMS(( ntbl_entry * ));
-extern	void	ic_install_jmp		PARAMS(( ntbl_entry *, Code *, int ));
-extern	void	ic_install_try_me_jmp	PARAMS(( ntbl_entry *, Code *, PWord ));
+extern	void	ic_install_overflow_call ( ntbl_entry * );
+extern	void	ic_install_call_entry	( ntbl_entry * );
+extern	void	ic_install_normal_exec_entry ( ntbl_entry * );
+extern	void	ic_install_spy		( ntbl_entry * );
+extern	void	ic_install_libbreak	( ntbl_entry *, int );
+extern	void	ic_install_decr_icount	( ntbl_entry * );
+extern	void	ic_install_resolve_ref	( ntbl_entry * );
+extern	void	ic_install_jmp		( ntbl_entry *, Code *, int );
+extern	void	ic_install_try_me_jmp	( ntbl_entry *, Code *, PWord );
 extern	void	ic_install_switch_on_term
-		    PARAMS((ntbl_entry *, Code *, Code *, Code *, Code *, int ));
-extern	void	ic_install_builtin	PARAMS(( ntbl_entry *, int (*) PARAMS(( void )) ));
-extern	void	ic_install_true		PARAMS(( ntbl_entry * ));
-extern	void	ic_install_fail		PARAMS(( ntbl_entry * ));
-extern	void	ic_install_equal	PARAMS(( ntbl_entry * ));
-extern	void	ic_install_call		PARAMS(( ntbl_entry *, long * ));
-extern	void	ic_install_module_closure PARAMS(( ntbl_entry *, Code * ));
+		    (ntbl_entry *, Code *, Code *, Code *, Code *, int );
+extern	void	ic_install_builtin	( ntbl_entry *, int (*) ( void ) );
+extern	void	ic_install_true		( ntbl_entry * );
+extern	void	ic_install_fail		( ntbl_entry * );
+extern	void	ic_install_equal	( ntbl_entry * );
+extern	void	ic_install_call		( ntbl_entry *, long * );
+extern	void	ic_install_module_closure ( ntbl_entry *, Code * );
 extern	void	ic_install_next_choice_in_a_deleted_clause
-					PARAMS(( Code * ));
-extern	void	ic_install_try_me	PARAMS(( Code *, PWord, int ));
-extern	void	ic_install_retry_me	PARAMS(( Code *, PWord, int, int ));
-extern	void	ic_install_trust_me	PARAMS(( Code *, PWord, int, int ));
-extern	long *	ic_install_try		PARAMS(( long *, Code *, int ));
-extern	long *	ic_install_retry	PARAMS(( long *, Code *, int, int ));
-extern	long *	ic_install_trust	PARAMS(( long *, Code *, int, int ));
-extern	Code *	ic_install_tree_overhead PARAMS(( long *, int, Code * ));
-extern	Code *	ic_install_no		PARAMS(( Code *, Code *, const char * ));
-extern	void	ic_install_reference	PARAMS(( Code *, PWord ));
+					( Code * );
+extern	void	ic_install_try_me	( Code *, PWord, int );
+extern	void	ic_install_retry_me	( Code *, PWord, int, int );
+extern	void	ic_install_trust_me	( Code *, PWord, int, int );
+extern	long *	ic_install_try		( long *, Code *, int );
+extern	long *	ic_install_retry	( long *, Code *, int, int );
+extern	long *	ic_install_trust	( long *, Code *, int, int );
+extern	Code *	ic_install_tree_overhead ( long *, int, Code * );
+extern	Code *	ic_install_no		( Code *, Code *, const char * );
+extern	void	ic_install_reference	( Code *, PWord );
 
 #if Portable
 /* icode1.c */
-extern	void	ic_punch		PARAMS(( Code *, Code ));
-extern	void	ic_putl			PARAMS(( PWord ));
-extern	void	ic_put_align		PARAMS(( Code ));
-extern	void	ic_put_reg		PARAMS(( Code, long ));
+extern	void	ic_punch		( Code *, Code );
+extern	void	ic_putl			( PWord );
+extern	void	ic_put_align		( Code );
+extern	void	ic_put_reg		( Code, long );
 /* icode2.c */
-extern	void	ic_install_bref		PARAMS(( ntbl_entry *, PWord, PWord ));
-extern	void	ic_install_instr	PARAMS(( ntbl_entry *, PWord, PWord ));
-extern	void	ic_install_tmjmp	PARAMS(( ntbl_entry *, long *, PWord ));
+extern	void	ic_install_bref		( ntbl_entry *, PWord, PWord );
+extern	void	ic_install_instr	( ntbl_entry *, PWord, PWord );
+extern	void	ic_install_tmjmp	( ntbl_entry *, long *, PWord );
 #define ic_install_try_me_jmp ic_install_tmjmp
 #endif /* Portable */
 

--- a/core/alsp_src/generic/index.c
+++ b/core/alsp_src/generic/index.c
@@ -92,18 +92,18 @@ static index_node *free_ptr;
 static int nodes_left;
 static jmp_buf alloc_overflow;
 
-static	void	initialize_nodeallocator PARAMS(( void ));
-static	index_node * alloc_node	PARAMS(( void ));
-static	void	insert_node	PARAMS(( index_header *, long, int, Code * ));
-static	void	compute_size	PARAMS(( index_header *, int, Code * ));
-static	int	computetablesize PARAMS(( int ));
-static	void	addtobuf	PARAMS(( int, index_header * ));
-static	switchTableEntry * walk_tree PARAMS(( index_node *, switchTableEntry *,
-					      int ));
-static	void	installtreeoverhead PARAMS(( int, int, switchTableEntry ** ));
-static	void	walk_bottom	PARAMS(( index_node *, int ));
+static	void	initialize_nodeallocator ( void );
+static	index_node * alloc_node	( void );
+static	void	insert_node	( index_header *, long, int, Code * );
+static	void	compute_size	( index_header *, int, Code * );
+static	int	computetablesize ( int );
+static	void	addtobuf	( int, index_header * );
+static	switchTableEntry * walk_tree ( index_node *, switchTableEntry *,
+					      int );
+static	void	installtreeoverhead ( int, int, switchTableEntry ** );
+static	void	walk_bottom	( index_node *, int );
 static	long *	get_clause_information
-				PARAMS (( long *, int *, long *, Code ** ));
+				( long *, int *, long *, Code ** );
 
 
 static void
@@ -613,8 +613,8 @@ walk_tree(ip, tp, isdet)
 #define wm_sw_const    W_SW_CONST
 #define wm_sw_struct   W_SW_STRUCT
 #else
-extern	void	wm_sw_const	PARAMS(( void ));
-extern	void	wm_sw_struct	PARAMS(( void ));
+extern	void	wm_sw_const	( void );
+extern	void	wm_sw_struct	( void );
 #endif
 
 /*

--- a/core/alsp_src/generic/lexan.c
+++ b/core/alsp_src/generic/lexan.c
@@ -38,7 +38,7 @@ lxi_but *lexbdp = &seetbl[USRSEEI].lb;	/* pointer to buffer descriptor */
 
 char  tokstr[1024];
 
-static	int	escape_char	PARAMS(( char ** ));
+static	int	escape_char	( char ** );
 
 /*----------------------------------------------------------------------*
  | next_token gets the next token from the input stream, classifies it and

--- a/core/alsp_src/generic/lexan.h
+++ b/core/alsp_src/generic/lexan.h
@@ -55,9 +55,9 @@ typedef struct _lex_buf {
             char *curpos;	/* pointer to next unprocessed character
                                    in the buffer                        */
             char *tokpos;	/* pointer to start of current token    */
-            void (*nextbuf) PARAMS(( struct _lex_buf * ));   
+            void (*nextbuf) ( struct _lex_buf * );
 	    					/* fnc responsible for getting next buffer */
-            int (*err_rec) PARAMS(( struct _lex_buf *, const char * ));
+            int (*err_rec) ( struct _lex_buf *, const char * );
 	    					/* fnc responsible for error message/recovery */
             int see_idx;	/* index into see table (if applicable) */
          } lxi_but;
@@ -65,8 +65,7 @@ typedef struct _lex_buf {
 extern lxi_but *lexbdp; /* lex buffer descriptor pointer */
 extern char lx_chtb[];
 
-#ifdef PARAMS			/* prevent lexinit.c from complaining */
-extern	void	next_token	PARAMS(( void ));
-#endif
+/* prevent lexinit.c from complaining */
+extern	void	next_token	( void );
 
 #endif /* LEXAN_H_INCLUDED */

--- a/core/alsp_src/generic/lforeign.c
+++ b/core/alsp_src/generic/lforeign.c
@@ -15,7 +15,7 @@
 /*#undef DynamicForeign */
 #ifdef DynamicForeign
 
-typedef void (*PFV) PARAMS(( void ));		/* A function pointer type */
+typedef void (*PFV) ( void );		/* A function pointer type */
 
 #if defined(HAVE_DLOPEN)
 
@@ -167,13 +167,13 @@ foreign_shutdown()
 #include <setjmp.h>
 #include <string.h>
 
-extern	int	ldclose		PARAMS(( LDFILE * ));
-extern	int	ldshread	PARAMS(( LDFILE *, unsigned int, SCNHDR * ));
-extern	int	ldtbread	PARAMS(( LDFILE *, long, SYMENT * ));
-extern	char *	ldgetname	PARAMS(( LDFILE *, CONST SYMENT * ));
-extern	int	ldnshread	PARAMS(( LDFILE *, CONST char *, SCNHDR * ));
-extern	char *	mktemp		PARAMS(( char * ));
-extern	int	unlink		PARAMS(( CONST char * ));
+extern	int	ldclose		( LDFILE * );
+extern	int	ldshread	( LDFILE *, unsigned int, SCNHDR * );
+extern	int	ldtbread	( LDFILE *, long, SYMENT * );
+extern	char *	ldgetname	( LDFILE *, const SYMENT * );
+extern	int	ldnshread	( LDFILE *, const char *, SCNHDR * );
+extern	char *	mktemp		( char * );
+extern	int	unlink		( const char * );
 
 /*  a symbol table file is an binary object */
 typedef struct {
@@ -203,18 +203,18 @@ typedef struct {
 } ENVIRONMENT;
 ENVIRONMENT Environment;	/* program environment */
 
-static	void	fatal		PARAMS(( char *, char * ));
-static	IMAGE *	CreateImage	PARAMS(( char * ));
-static	void	DestroyImage	PARAMS(( IMAGE * ));
-static	void	DestroyImages	PARAMS(( void ));
-static	void	TraverseSectionsImage PARAMS(( IMAGE * ));
-static	long	FindSymbolValue	PARAMS(( char * ));
-static	long	GetSectionStart	PARAMS(( char * ));
-static	char *	xtext_and_xdata_strings PARAMS(( long, long , char *, long ));
-static	char *	GenerateCoffFile PARAMS(( IMAGE *, IMAGE * ));
-static	IMAGE *	CreateSymbolTable PARAMS(( IMAGE *, IMAGE *, char * ));
-static	void	CreateEnvironment PARAMS(( void ));
-static	void	Load		PARAMS(( char *, char * ));
+static	void	fatal		( char *, char * );
+static	IMAGE *	CreateImage	( char * );
+static	void	DestroyImage	( IMAGE * );
+static	void	DestroyImages	( void );
+static	void	TraverseSectionsImage ( IMAGE * );
+static	long	FindSymbolValue	( char * );
+static	long	GetSectionStart	( char * );
+static	char *	xtext_and_xdata_strings ( long, long , char *, long );
+static	char *	GenerateCoffFile ( IMAGE *, IMAGE * );
+static	IMAGE *	CreateSymbolTable ( IMAGE *, IMAGE *, char * );
+static	void	CreateEnvironment ( void );
+static	void	Load		( char *, char * );
 
 jmp_buf fatalbuf;
 

--- a/core/alsp_src/generic/loadfile.c
+++ b/core/alsp_src/generic/loadfile.c
@@ -638,12 +638,12 @@ obp_pop()
 
 #if (defined(__DJGPP__) || defined(__GO32__))
 
-static	long	get_file_modified_time	PARAMS(( CONST char * ));
-static	int	isdir			PARAMS((CONST char * ));
+static	long	get_file_modified_time	( const char * );
+static	int	isdir			(const char * );
 
 static long 
 get_file_modified_time(fname)
-    CONST char *fname;
+    const char *fname;
 {
 #if defined(DOS)
 
@@ -691,7 +691,7 @@ get_file_modified_time(fname)
  */
 static int
 isdir(fname)
-    CONST char *fname;
+    const char *fname;
 {
 #if defined(DOS)
 

--- a/core/alsp_src/generic/main.c
+++ b/core/alsp_src/generic/main.c
@@ -116,20 +116,20 @@ static char versionYear[] = VERSION_YEAR;	/* from version.h */
 static int exit_status = 0;
 static jmp_buf exit_return; 
 
-static	void	panic_fail	PARAMS(( void ));
+static	void	panic_fail	( void );
 #ifdef arch_m88k
-static	void	panic_continue	PARAMS(( void ));
+static	void	panic_continue	( void );
 #endif
-static	void	abolish_predicate PARAMS(( const char *, const char *, int ));
-static	void	assert_sys_searchdir PARAMS(( char * ));
-static	void	assert_als_system PARAMS((const char *, const char *,
+static	void	abolish_predicate ( const char *, const char *, int );
+static	void	assert_sys_searchdir ( char * );
+static	void	assert_als_system (const char *, const char *,
 					  const char *, const char *,
-					  const char *, const char *));
-static	void	assert_atom_in_module PARAMS(( const char*, const char * ));
+					  const char *, const char *);
+static	void	assert_atom_in_module ( const char*, const char * );
 
 
-static	void	autoload	PARAMS(( char * ));
-static	void	chpt_init	PARAMS(( void ));
+static	void	autoload	( char * );
+static	void	chpt_init	( void );
 
 static void
 panic_fail()
@@ -808,7 +808,7 @@ chpt_init()
  | backs.  Who knows, maybe someday we will want to call it.
  *-------------------------------------------------------------------*/
 
-extern	char *	copyright	PARAMS(( void ));
+extern	char *	copyright	( void );
 
 char *
 copyright()

--- a/core/alsp_src/generic/mapsym.c
+++ b/core/alsp_src/generic/mapsym.c
@@ -102,7 +102,7 @@
  * on the to_free list.  The block returned will be longword aligned.
  */
 
-static long * alloc	PARAMS(( size_t, long ** ));
+static long * alloc	( size_t, long ** );
 static long *
 alloc(size, to_free_ptr)
     size_t size;
@@ -133,7 +133,7 @@ alloc(size, to_free_ptr)
  * free_em will free up the space allocated by successive calls to alloc.
  */
 
-static	void	free_em		PARAMS(( long * ));
+static	void	free_em		( long * );
 static void
 free_em(to_free)
     long *to_free;
@@ -252,7 +252,7 @@ pop_symmap()
  * new_bucket is called internally to get a new bucket block
  */
 
-static	struct bucket_block * new_bucket PARAMS(( void ));
+static	struct bucket_block * new_bucket ( void );
 
 static struct bucket_block *
 new_bucket()

--- a/core/alsp_src/generic/mem.c
+++ b/core/alsp_src/generic/mem.c
@@ -106,12 +106,12 @@
 
 /*//static long *als_mem;*/
 
-long *	alloc_big_block		PARAMS(( size_t, int ));
-static	long *	ss_malloc0		PARAMS(( size_t, int, int, long * ));
+long *	alloc_big_block		( size_t, int );
+static	long *	ss_malloc0		( size_t, int, int, long * );
 #ifndef PURE_ANSI
-static	void	ss_restore_state	PARAMS(( const char *, long ));
+static	void	ss_restore_state	( const char *, long );
 #endif /* PURE_ANSI */
-static	int	ss_saved_state_present	PARAMS(( void ));
+static	int	ss_saved_state_present	( void );
 
 #define amheader (* (struct am_header *) als_mem)
 

--- a/core/alsp_src/generic/module.h
+++ b/core/alsp_src/generic/module.h
@@ -61,37 +61,37 @@
 #pragma pointers_in_D0
 #endif
 
-extern	Code *	resolve_reference PARAMS( (ntbl_entry *) );
+extern	Code *	resolve_reference (ntbl_entry *);
 
 #ifdef POINTERS_IN_A0
 #pragma pointers_in_A0
 #endif
 
-extern	ntbl_entry * resolve_ref PARAMS( (PWord, PWord, int) );
+extern	ntbl_entry * resolve_ref (PWord, PWord, int);
 
 #ifdef POINTERS_IN_A0
 #pragma pointers_in_D0
 #endif
 
-extern	Code *	call_resolve_reference PARAMS( (PWord, PWord, int, int) );
+extern	Code *	call_resolve_reference (PWord, PWord, int, int);
 
 #ifdef POINTERS_IN_A0
 #pragma pointers_in_A0
 #endif
 
-extern	int		next_module	PARAMS( (int, PWord *, int *, PWord *, int *) );
-extern	int		mod_id		PARAMS( (int) );
-extern	int		modprobe_id	PARAMS( (PWord) );
-extern	void	new_mod		PARAMS( (PWord) );
-extern	void	end_mod		PARAMS( (void) );
-extern	void	push_clausegroup PARAMS( (int) );
-extern	int		pop_clausegroup	PARAMS( (void) );
-extern	void	add_default_use	PARAMS( (int) );
-extern	void	add_default_proc PARAMS( (PWord, int) );
-extern	void	adduse		PARAMS( (int, int) );
-extern	void	export_pred	PARAMS( (PWord, PWord, int) );
-extern	void	createModuleClosureProcedure PARAMS( (PWord, int, PWord) );
-extern  int		createModCloseProc	PARAMS( (int, PWord, int, PWord) );
-extern	void	module_init	PARAMS( (void) );
+extern	int		next_module	(int, PWord *, int *, PWord *, int *);
+extern	int		mod_id		(int);
+extern	int		modprobe_id	(PWord);
+extern	void	new_mod		(PWord);
+extern	void	end_mod		(void);
+extern	void	push_clausegroup (int);
+extern	int		pop_clausegroup	(void);
+extern	void	add_default_use	(int);
+extern	void	add_default_proc (PWord, int);
+extern	void	adduse		(int, int);
+extern	void	export_pred	(PWord, PWord, int);
+extern	void	createModuleClosureProcedure (PWord, int, PWord);
+extern  int		createModCloseProc	(int, PWord, int, PWord);
+extern	void	module_init	(void);
 
 #endif /* _MODULE_H_INCLUDED_ */

--- a/core/alsp_src/generic/parser.c
+++ b/core/alsp_src/generic/parser.c
@@ -77,21 +77,21 @@ static pword ps_rand[PSTKSZ];
 
 int   errcount = 0;
 
-static	void	bld_struct	PARAMS(( void ));
-static	int	reduce_stack	PARAMS(( int ));
-static	void	push_op		PARAMS(( int ));
-static	void	nt_term0	PARAMS(( void ));
-static	void	nt_term		PARAMS(( int ));
-static	void	nt_list		PARAMS(( void ));
-static	void	nt_listexpr	PARAMS(( void ));
-static	void	nt_args		PARAMS(( void ));
-static	void	nt_uselist	PARAMS(( void ));
-static	void	nt_exportlist	PARAMS(( void ));
-static	void	check_sym	PARAMS(( const char * ));
-static	void	nt_toplevel	PARAMS(( void ));
-static	int	bottomRead	PARAMS(( const char *, const char * ));
-static	void	buf_nextline	PARAMS(( lxi_but * ));
-static	int	buf_syntaxerror	PARAMS(( lxi_but *, const char * ));
+static	void	bld_struct	( void );
+static	int	reduce_stack	( int );
+static	void	push_op		( int );
+static	void	nt_term0	( void );
+static	void	nt_term		( int );
+static	void	nt_list		( void );
+static	void	nt_listexpr	( void );
+static	void	nt_args		( void );
+static	void	nt_uselist	( void );
+static	void	nt_exportlist	( void );
+static	void	check_sym	( const char * );
+static	void	nt_toplevel	( void );
+static	int	bottomRead	( const char *, const char * );
+static	void	buf_nextline	( lxi_but * );
+static	int	buf_syntaxerror	( lxi_but *, const char * );
 
 
 /*
@@ -748,7 +748,7 @@ parser_error(errstring)
 
 void
 read_loop(rdfunc, pptidx)
-    void  (*rdfunc) PARAMS(( void ));
+    void  (*rdfunc) ( void );
     int   pptidx;
 {
     int   eof = 0;

--- a/core/alsp_src/generic/parser.h
+++ b/core/alsp_src/generic/parser.h
@@ -93,42 +93,38 @@ extern long *char_to_tok_map;
 extern char tokstr[];		/* defined in lexan.c */
 
 
-#ifdef PARAMS			/* prevent errors in bldtok.c */
-
 /* symtab.c */
-extern	void	symtab_init	PARAMS(( void ));
-extern	long	find_token	PARAMS(( const UCHAR * ));
-extern	long	probe_token	PARAMS(( UCHAR * ));
-extern	int	tok_table_size	PARAMS((void));
+extern	void	symtab_init	( void );
+extern	long	find_token	( const UCHAR * );
+extern	long	probe_token	( UCHAR * );
+extern	int	tok_table_size	(void);
 
 /* parser.c */
-extern	void	parser_init	PARAMS(( void ));
-extern	void	parser_reset	PARAMS(( void ));
-extern	int	find_var	PARAMS(( char * ));
-extern	void	push_rator	PARAMS(( long, long ));
-extern	void	bld_clause	PARAMS(( void ));
-extern	void	nt_query	PARAMS(( void ));
-extern	void	parser_error	PARAMS(( const char * ));
-extern	void	read_loop	PARAMS(( void (*) PARAMS((void)), int ));
-extern	pword	bld_strl	PARAMS(( char * ));
-extern	pword	bld_vlst	PARAMS(( void ));
-extern	int	qtok		PARAMS(( int ));
-extern	void	bld_showanswers	PARAMS(( void ));
-extern	int	consult		PARAMS(( int ));
-extern	pword	prim_read	PARAMS(( void ));
-extern	int	exec_query_from_buf PARAMS(( char * ));
-extern	UCHAR *	token_name	PARAMS(( int ));
+extern	void	parser_init	( void );
+extern	void	parser_reset	( void );
+extern	int	find_var	( char * );
+extern	void	push_rator	( long, long );
+extern	void	bld_clause	( void );
+extern	void	nt_query	( void );
+extern	void	parser_error	( const char * );
+extern	void	read_loop	( void (*) (void), int );
+extern	pword	bld_strl	( char * );
+extern	pword	bld_vlst	( void );
+extern	int	qtok		( int );
+extern	void	bld_showanswers	( void );
+extern	int	consult		( int );
+extern	pword	prim_read	( void );
+extern	int	exec_query_from_buf ( char * );
+extern	UCHAR *	token_name	( int );
 
 /* mapsym.c */
-extern	void	push_symmap	PARAMS(( void ));
-extern	void	pop_symmap	PARAMS(( void ));
-extern	long	symmap		PARAMS(( long ));
-extern	long *	sym_order	PARAMS(( long * ));
+extern	void	push_symmap	( void );
+extern	void	pop_symmap	( void );
+extern	long	symmap		( long );
+extern	long *	sym_order	( long * );
 
 /* expand.c */
-extern	void	parser_action	PARAMS(( int, pword ));
-extern	pword	cvt_term_to_rule PARAMS(( PWord, int ));
-
-#endif /* PARAMS */
+extern	void	parser_action	( int, pword );
+extern	pword	cvt_term_to_rule ( PWord, int );
 
 #endif /* __parser_h_ */

--- a/core/alsp_src/generic/pckg.h
+++ b/core/alsp_src/generic/pckg.h
@@ -9,7 +9,7 @@
 
 
 extern long *system_pckg; 		/* currently loaded package */
-extern	void	pckg_run_init_goal	PARAMS(( void ));
+extern	void	pckg_run_init_goal	( void );
 
 #ifdef PACKAGE
 

--- a/core/alsp_src/generic/relocate_code.c
+++ b/core/alsp_src/generic/relocate_code.c
@@ -26,8 +26,8 @@ static struct _icode {
 };
 #undef ABMOP
 
-enum AbstractMachineOps decode_instr PARAMS(( Code ));
-int	display_instr	PARAMS( (enum AbstractMachineOps, Code *));
+enum AbstractMachineOps decode_instr ( Code );
+int	display_instr	(enum AbstractMachineOps, Code *);
 
 
 

--- a/core/alsp_src/generic/sig.c
+++ b/core/alsp_src/generic/sig.c
@@ -48,9 +48,9 @@
  * Control/C handler and structure to store original handler.
  */
 
-extern int cntrlc_handler PARAMS((void));
-extern int endof_cntrlc_handler PARAMS((void));
-extern int set_prolog_interrupt PARAMS((void));
+extern int cntrlc_handler (void);
+extern int endof_cntrlc_handler (void);
+extern int set_prolog_interrupt (void);
 
 struct intvec_struc {
     long  prot_vec_addr;
@@ -101,7 +101,7 @@ void  signal_handler(AST_param)
     char  AST_param;
 #else
 #define NAIVE_SIGNAL_HANDLER 1
-extern int set_prolog_interrupt	PARAMS((void));
+extern int set_prolog_interrupt	(void);
 void  signal_handler(signum)
     int   signum;
 #endif 		/* defined(HAVE_UCONTEXT_H) */
@@ -500,7 +500,7 @@ int pbi_alarm(void)
 #define SIGCHLD SIGCLD
 #endif
 
-static	void	burychild	PARAMS(( int ));
+static	void	burychild	( int );
 
 static void
 burychild(signo)

--- a/core/alsp_src/generic/sig.h
+++ b/core/alsp_src/generic/sig.h
@@ -13,21 +13,21 @@
 #if defined(HAVE_UCONTEXT_H)
 #include <ucontext.h>
 
-extern	void	signal_handler	PARAMS(( int, siginfo_t *, ucontext_t *));
+extern	void	signal_handler	( int, siginfo_t *, ucontext_t *);
 
 #elif defined(arch_m88k)
-extern	void	signal_handler	PARAMS(( int, struct siginfo * ));
+extern	void	signal_handler	( int, struct siginfo * );
 
 #elif defined(HAVE_SIGVEC)
-extern	void  signal_handler	PARAMS(( int, int, struct sigcontext *, char * ));
+extern	void  signal_handler	( int, int, struct sigcontext *, char * );
 
 #elif defined(HAVE_SIGVECTOR)
-extern	void  signal_handler	PARAMS(( int, int, struct sigcontext *, char * ));
+extern	void  signal_handler	( int, int, struct sigcontext *, char * );
 
 #elif defined(VMS)
-extern	void  signal_handler	PARAMS(( char ));	/* !!? */
+extern	void  signal_handler	( char );	/* !!? */
 
 #else		/* otherwise */
-extern	void  signal_handler	PARAMS(( int ));
+extern	void  signal_handler	( int );
 
 #endif

--- a/core/alsp_src/generic/symtab.c
+++ b/core/alsp_src/generic/symtab.c
@@ -154,9 +154,9 @@ static tkentry initial_table[] =
 /*//long *char_to_tok_map;*/
 
 /* Prototypes */
-static	tkentry ** lookup		PARAMS(( UCHAR *, size_t * ));
-static	void	new_string_space	PARAMS(( size_t ));
-static	void	increase_table_size	PARAMS(( void ));
+static	tkentry ** lookup		( UCHAR *, size_t * );
+static	void	new_string_space	( size_t );
+static	void	increase_table_size	( void );
 
 
 

--- a/core/alsp_src/generic/varproc.c
+++ b/core/alsp_src/generic/varproc.c
@@ -23,12 +23,12 @@ varinf vtbl[VTBLSIZE + 2];	/* variable table               */
 
 int   call_env_sizes[MAXGLS];
 
-static	void	init_vtbl	PARAMS(( int ));
-static	void	vwalk_term	PARAMS(( pword, int, int ));
-static	void	vwalk_const	PARAMS(( pword, int, int ));
-static	void	vwalk_list	PARAMS(( pword, int, int ));
-static	void	vwalk_rule	PARAMS(( pword, int, int ));
-static	void	vwalk_vo	PARAMS(( pword, int, int ));
+static	void	init_vtbl	( int );
+static	void	vwalk_term	( pword, int, int );
+static	void	vwalk_const	( pword, int, int );
+static	void	vwalk_list	( pword, int, int );
+static	void	vwalk_rule	( pword, int, int );
+static	void	vwalk_vo	( pword, int, int );
 
 static void
 init_vtbl(n)
@@ -57,7 +57,7 @@ init_vtbl(n)
 
 #define vwalk(t) vwalk_rule(t,-1,-1)
 
-static void (*vwalk_tbl[]) PARAMS(( pword, int, int )) = {
+static void (*vwalk_tbl[]) ( pword, int, int ) = {
     vwalk_term,
 	vwalk_const,
 	vwalk_list,

--- a/core/alsp_src/generic/varproc.h
+++ b/core/alsp_src/generic/varproc.h
@@ -45,10 +45,10 @@ extern int call_env_sizes[];	/* size of environment for each call (goal) in body
 #define ENVIDX VTBLSIZE
 
 /* ----------- varproc.c ----------- */
-extern	int		classify_vars		PARAMS(( pword ));
-extern	void	compute_call_env_sizes	PARAMS(( int, int ));
+extern	int		classify_vars		( pword );
+extern	void	compute_call_env_sizes	( int, int );
 
 /* ----------- compile.c ----------- */
 #ifdef NewMath
-extern	int	isarithmetic		PARAMS(( pword ));
+extern	int	isarithmetic		( pword );
 #endif

--- a/core/alsp_src/generic/wdisp.c
+++ b/core/alsp_src/generic/wdisp.c
@@ -37,27 +37,27 @@
  *
  */
 
-static	void	wr_trm		PARAMS(( PWord, int, int ));
-static	void	wr_int		PARAMS(( PWord, int, int ));
-static	void	wr_lst		PARAMS(( PWord, int, int ));
-static	void	wr_sym		PARAMS(( PWord, int, int ));
-static	void	wr_var		PARAMS(( PWord, int, int ));
-static	void	wr_uia		PARAMS(( PWord, int, int ));
+static	void	wr_trm		( PWord, int, int );
+static	void	wr_int		( PWord, int, int );
+static	void	wr_lst		( PWord, int, int );
+static	void	wr_sym		( PWord, int, int );
+static	void	wr_var		( PWord, int, int );
+static	void	wr_uia		( PWord, int, int );
 
-static	int	wr_op2		PARAMS(( PWord, int, long, int, int ));
-static	int	wr_op		PARAMS(( PWord, long, int, int ));
-static	void	write_quoted_symbol PARAMS(( char * ));
+static	int	wr_op2		( PWord, int, long, int, int );
+static	int	wr_op		( PWord, long, int, int );
+static	void	write_quoted_symbol ( char * );
 
 #ifdef DoubleType
-static	void	wr_dbl		PARAMS(( PWord, int, int ));
-static	int	check_vector	PARAMS(( long *, long * ));
-static	void	print_vector	PARAMS(( long *, long ));
-static	void	craig_get_double PARAMS(( double *, long * ));
+static	void	wr_dbl		( PWord, int, int );
+static	int	check_vector	( long *, long * );
+static	void	print_vector	( long *, long );
+static	void	craig_get_double ( double *, long * );
 #endif /* DoubleType */
 
 /* This order has to match up with the WTP_type constants in winter.h */
 
-static void (*wr_tbl[]) PARAMS(( PWord, int, int )) = {
+static void (*wr_tbl[]) ( PWord, int, int ) = {
 	wr_var,
 	wr_lst,
 	wr_trm,

--- a/core/alsp_src/generic/wintcode.c
+++ b/core/alsp_src/generic/wintcode.c
@@ -28,7 +28,7 @@
 #include <sys/mman.h>
 
 #elif	defined(arch_m88k)  /* !HAME_MMAP */
-extern	int	memctl		PARAMS(( void *, int, int ));
+extern	int	memctl		( void *, int, int );
 
 #endif /* HAVE_MMAP */
 
@@ -77,14 +77,14 @@ long *aib_clause_addr;		/* used by assertz */
 
 /*//static struct codeblock *codeblock_list = (struct codeblock *) 0;*/
 
-static	long *	code_alloc	PARAMS(( size_t, int ));
-static	void	makerunable	PARAMS(( void ));
-static	void	makewritable	PARAMS(( void ));
-static	ntbl_entry * alloc_name_entry PARAMS(( void ));
-static	long *	cbsffa		PARAMS(( Code * ));
-static	long *	clause_start_from_retaddr PARAMS(( Code *, long * ));
-static	void	mark_fromretaddr PARAMS(( Code * ));
-static	void	mark_clause	PARAMS(( long * ));
+static	long *	code_alloc	( size_t, int );
+static	void	makerunable	( void );
+static	void	makewritable	( void );
+static	ntbl_entry * alloc_name_entry ( void );
+static	long *	cbsffa		( Code * );
+static	long *	clause_start_from_retaddr ( Code *, long * );
+static	void	mark_fromretaddr ( Code * );
+static	void	mark_clause	( long * );
 
 /*-----------------------------------------------------------------*
  | code_alloc
@@ -684,9 +684,9 @@ w_installcode(buffer, bufsize, extra, actualsize)
  | copy_code procedure for the 88k.
  *-----------------------------------------------------------------*/
 
-extern	void	wm_g_uia	PARAMS(( void ));
-extern	void	wm_p_uia	PARAMS(( void ));
-extern	void	mth_pushdbl0	PARAMS(( void ));
+extern	void	wm_g_uia	( void );
+extern	void	wm_p_uia	( void );
+extern	void	mth_pushdbl0	( void );
 
 void
 copy_code(buffer, to, bufsize)
@@ -755,9 +755,9 @@ copy_code(buffer, to, bufsize)
 #else  /* arch_m88k */
 #ifdef arch_sparc
 
-extern	void	wm_g_uia	PARAMS(( void ));
-extern	void	wm_p_uia	PARAMS(( void ));
-extern	void	mth_pushdbl0	PARAMS(( void ));
+extern	void	wm_g_uia	( void );
+extern	void	wm_p_uia	( void );
+extern	void	mth_pushdbl0	( void );
 
 /*-----------------------------------------------------------------*
  * copy_code procedure for the Sparc.
@@ -1735,7 +1735,7 @@ void
 w_assert_builtin(name, arity, builtin)
     const char *name;
     int   arity;
-    int   (*builtin) PARAMS(( void ));
+    int   (*builtin) ( void );
 {
     ntbl_entry *ent;
 
@@ -1750,7 +1750,7 @@ void
 w_assert_built2(name, arity, installer, p1, p2)
     const char *name;
     int   arity;
-    void  (*installer) PARAMS(( ntbl_entry *, PWord, PWord ));
+    void  (*installer) ( ntbl_entry *, PWord, PWord );
     PWord p1, p2;
 {
     ntbl_entry *ent;
@@ -1780,7 +1780,7 @@ w_assert_foreign(modid, name, arity, builtin)
     PWord modid;
     const char *name;
     int   arity;
-    int   (*builtin) PARAMS(( void ));
+    int   (*builtin) ( void );
 {
     ntbl_entry *ent;
 

--- a/core/alsp_src/generic/wintcode.h
+++ b/core/alsp_src/generic/wintcode.h
@@ -314,78 +314,78 @@ extern	unsigned long w_timestamp;
 extern	unsigned long w_reconstamp;
 extern	PWord	wm_aborted;
 
-extern	dbprot_t w_dbprotect	PARAMS(( dbprot_t ));
-extern	int	w_namelookup	PARAMS(( PWord, PWord, int ));
-extern	ntbl_entry *w_nameprobe PARAMS(( PWord, PWord, int ));
-extern	ntbl_entry *w_nameentry	PARAMS(( PWord, PWord, int ));
-extern	void	w_initcode	PARAMS(( void ));
-extern	void	w_freecount	PARAMS(( long *, long * ));
-extern	long *	w_alloccode	PARAMS(( int ));
-extern	void	w_freecode	PARAMS(( long * ));
-extern	long *	w_installcode	PARAMS(( Code *, int, int, int* ));
-extern	void	copy_code	PARAMS(( long *, long *, int ));
-extern	void	w_nukeindexing	PARAMS(( ntbl_entry * ));
-extern	void	w_fixchoicepoints PARAMS(( long * ));
-extern	void	w_abolish	PARAMS(( ntbl_entry * ));
-extern	int	w_erase		PARAMS(( int, long * ));
-extern	void	w_freeclause	PARAMS(( long * ));
-extern	void	w_assertz	PARAMS(( PWord, int, Code *, int,
-                                         long, int, int, long ));
-extern	void	w_asserta	PARAMS(( PWord, int, Code *, int,
-					 long, int, int, long ));
-extern	void	w_addclause	PARAMS(( PWord, int, int, Code *,
+extern	dbprot_t w_dbprotect	( dbprot_t );
+extern	int	w_namelookup	( PWord, PWord, int );
+extern	ntbl_entry *w_nameprobe ( PWord, PWord, int );
+extern	ntbl_entry *w_nameentry	( PWord, PWord, int );
+extern	void	w_initcode	( void );
+extern	void	w_freecount	( long *, long * );
+extern	long *	w_alloccode	( int );
+extern	void	w_freecode	( long * );
+extern	long *	w_installcode	( Code *, int, int, int* );
+extern	void	copy_code	( long *, long *, int );
+extern	void	w_nukeindexing	( ntbl_entry * );
+extern	void	w_fixchoicepoints ( long * );
+extern	void	w_abolish	( ntbl_entry * );
+extern	int	w_erase		( int, long * );
+extern	void	w_freeclause	( long * );
+extern	void	w_assertz	( PWord, int, Code *, int,
+                                         long, int, int, long );
+extern	void	w_asserta	( PWord, int, Code *, int,
+					 long, int, int, long );
+extern	void	w_addclause	( PWord, int, int, Code *,
 					 int, long, int, int,
-					 long ));
-extern	void	w_abolish_cg	PARAMS(( ntbl_entry *, int, int ));
-extern	void	w_execquery	PARAMS(( Code *, int ));
-extern	void	w_execcommand	PARAMS(( Code *, int ));
-extern	void	w_exec		PARAMS(( Code *, int, const char* ));
-extern	void	w_assert_builtin PARAMS(( const char *, int, int (*) PARAMS(( void )) ));
-extern	void	w_assert_built2	PARAMS(( const char *, int, void (*) PARAMS(( ntbl_entry *, PWord, PWord )), PWord, PWord ));
-extern	void	w_assert_foreign PARAMS(( PWord, const char *, int, int (*) PARAMS(( void )) ));
-extern	void	w_dynamic	PARAMS(( PWord, PWord, int ));
-extern	int	w_spy		PARAMS(( PWord, PWord, int ));
-extern	int	w_nospy		PARAMS(( PWord, PWord, int ));
-extern	void	w_libbreak	PARAMS(( PWord, PWord, int ,int ));
-extern	PWord	nextproc	PARAMS(( PWord, int ));
-extern	long *	first_clause	PARAMS(( int ));
-extern	long *	next_clause	PARAMS(( long * ));
-extern	void	make_dbref	PARAMS(( long *, PWord *, int * ));
-extern	long *	w_validate_dbref PARAMS(( long *, int nid, long cid ));
+					 long );
+extern	void	w_abolish_cg	( ntbl_entry *, int, int );
+extern	void	w_execquery	( Code *, int );
+extern	void	w_execcommand	( Code *, int );
+extern	void	w_exec		( Code *, int, const char* );
+extern	void	w_assert_builtin ( const char *, int, int (*) ( void ) );
+extern	void	w_assert_built2	( const char *, int, void (*) ( ntbl_entry *, PWord, PWord ), PWord, PWord );
+extern	void	w_assert_foreign ( PWord, const char *, int, int (*) ( void ) );
+extern	void	w_dynamic	( PWord, PWord, int );
+extern	int	w_spy		( PWord, PWord, int );
+extern	int	w_nospy		( PWord, PWord, int );
+extern	void	w_libbreak	( PWord, PWord, int ,int );
+extern	PWord	nextproc	( PWord, int );
+extern	long *	first_clause	( int );
+extern	long *	next_clause	( long * );
+extern	void	make_dbref	( long *, PWord *, int * );
+extern	long *	w_validate_dbref ( long *, int nid, long cid );
 #ifdef POINTERS_IN_A0
 #pragma pointers_in_D0
 #endif
-extern	long *	validate_dbref	PARAMS(( PWord, int, PWord * ));
-extern	Code *	jump_validate_dbref PARAMS(( PWord ref, PWord term ));
+extern	long *	validate_dbref	( PWord, int, PWord * );
+extern	Code *	jump_validate_dbref ( PWord ref, PWord term );
 #ifdef POINTERS_IN_A0
 #pragma pointers_in_A0
 #endif
-extern	void	gen_indexing	PARAMS(( void ));
-extern	void	decr_icount	PARAMS(( Code * ));
-extern	void	seticount	PARAMS(( ntbl_entry * ));
+extern	void	gen_indexing	( void );
+extern	void	decr_icount	( Code * );
+extern	void	seticount	( ntbl_entry * );
 #ifdef POINTERS_IN_A0
 #pragma pointers_in_D0
 #endif
-extern	long *	next_choice_in_a_deleted_clause PARAMS(( long * ));
+extern	long *	next_choice_in_a_deleted_clause ( long * );
 #ifdef POINTERS_IN_A0
 #pragma pointers_in_A0
 #endif
-extern	void	w_collect	PARAMS(( void ));
-extern	PWord *	w_frame_info	PARAMS(( PWord *, long **, long * ));
-extern	void	w_relink	PARAMS(( ntbl_entry * ));
-extern	void	w_relinkall	PARAMS(( void ));
-extern	char *	w_getnamestring	PARAMS(( Code *, char * ));
-extern	int	nameprobe	PARAMS(( PWord, PWord, int ));
+extern	void	w_collect	( void );
+extern	PWord *	w_frame_info	( PWord *, long **, long * );
+extern	void	w_relink	( ntbl_entry * );
+extern	void	w_relinkall	( void );
+extern	char *	w_getnamestring	( Code *, char * );
+extern	int	nameprobe	( PWord, PWord, int );
 
 /*-----------------------------------------------------------------*
  | from index.c 
  *-----------------------------------------------------------------*/
-extern	void	indexproc	PARAMS(( PWord, PWord, int ));
-extern	void	do_indexing	PARAMS(( ntbl_entry * ));
+extern	void	indexproc	( PWord, PWord, int );
+extern	void	do_indexing	( ntbl_entry * );
 
 /*-----------------------------------------------------------------*
  | from gc.c 
  *-----------------------------------------------------------------*/
-extern	int	gc		PARAMS(( void ));
+extern	int	gc		( void );
 
 #endif /* _WINTCODE_H_INCLUDED_ */

--- a/core/alsp_src/generic/winter.c
+++ b/core/alsp_src/generic/winter.c
@@ -72,7 +72,7 @@ long *Fail;
 
 #define round(x,s) ((((x)-1) & ~(long)((s)-1)) + (s))
 
-PWord	deref		PARAMS(( PWord ));
+PWord	deref		( PWord );
 
 #ifdef DEBUG
 static int valid_pword(PWord p)

--- a/core/alsp_src/generic/winter.h
+++ b/core/alsp_src/generic/winter.h
@@ -135,8 +135,8 @@ extern PWord wm_spying;
 /*//extern Code *wm_trust_fail;*/
 /*//extern Code *wm_panic;*/
 #else
-extern	int	wm_fail		PARAMS(( void ));
-extern	int	wm_trust_fail	PARAMS(( void ));
+extern	int	wm_fail		( void );
+extern	int	wm_trust_fail	( void );
 #endif /* Portable */
 
 /*@[3.1]@------------------------------------------------------------------
@@ -179,49 +179,49 @@ extern	int	wm_trust_fail	PARAMS(( void ));
  * Declarations and prototypes for functions defined in winter.c
  */
 
-extern	void	w_get PARAMS(( PWord *, int *, PWord ));
-extern	void	w_install PARAMS(( PWord *, PWord, int ));
-extern	void	w_install_argn PARAMS(( PWord s, int n, PWord v, int t ));
-extern	void	w_install_unbound_argn PARAMS(( PWord, int ));
-extern	void	w_get_argn PARAMS(( PWord *, int *, PWord, int ));
-extern	void	w_mk_term PARAMS(( PWord *, int *, PWord, int ));
-extern	void	w_get_functor PARAMS(( PWord *, PWord ));
-extern	void	w_get_arity PARAMS(( int *, PWord ));
-extern	void	w_mk_list PARAMS(( PWord *, int * ));
-extern	void	w_mk_unbound PARAMS(( PWord *, int * ));
-extern	void	w_get_An PARAMS(( PWord *, int *, int ));
-extern	UCHAR *	w_get_uianame PARAMS(( UCHAR *, PWord, int ));
-extern	void	w_mk_uia PARAMS(( PWord *, int *, UCHAR * ));
-extern	void	w_mk_len_uia PARAMS(( PWord *, int *, UCHAR * , size_t));
-extern	void	w_mk_uia_in_place PARAMS(( PWord *, int *, UCHAR * ));
-extern	void	w_uia_alloc PARAMS(( PWord *, int *, size_t ));
-extern	int	w_uia_clip PARAMS(( PWord, int) );
-extern	int	w_uia_peek PARAMS(( PWord, int, UCHAR *, int ));
-extern	int	w_uia_poke PARAMS(( PWord, int, UCHAR *, int ));
-extern	int	w_uia_peeks PARAMS(( PWord, int, UCHAR *, int ));
-extern	int	w_uia_pokes PARAMS(( PWord, int, UCHAR * ));
-extern	void	w_mk_double PARAMS(( PWord *, int *, double ));
-extern	void	w_get_double PARAMS(( double *, PWord ));
-extern	int	w_unify PARAMS(( PWord, int, PWord, int ));
-extern	int	w_rungoal PARAMS(( PWord, PWord, int ));
+extern	void	w_get ( PWord *, int *, PWord );
+extern	void	w_install ( PWord *, PWord, int );
+extern	void	w_install_argn ( PWord s, int n, PWord v, int t );
+extern	void	w_install_unbound_argn ( PWord, int );
+extern	void	w_get_argn ( PWord *, int *, PWord, int );
+extern	void	w_mk_term ( PWord *, int *, PWord, int );
+extern	void	w_get_functor ( PWord *, PWord );
+extern	void	w_get_arity ( int *, PWord );
+extern	void	w_mk_list ( PWord *, int * );
+extern	void	w_mk_unbound ( PWord *, int * );
+extern	void	w_get_An ( PWord *, int *, int );
+extern	UCHAR *	w_get_uianame ( UCHAR *, PWord, int );
+extern	void	w_mk_uia ( PWord *, int *, UCHAR * );
+extern	void	w_mk_len_uia ( PWord *, int *, UCHAR * , size_t);
+extern	void	w_mk_uia_in_place ( PWord *, int *, UCHAR * );
+extern	void	w_uia_alloc ( PWord *, int *, size_t );
+extern	int	w_uia_clip ( PWord, int);
+extern	int	w_uia_peek ( PWord, int, UCHAR *, int );
+extern	int	w_uia_poke ( PWord, int, UCHAR *, int );
+extern	int	w_uia_peeks ( PWord, int, UCHAR *, int );
+extern	int	w_uia_pokes ( PWord, int, UCHAR * );
+extern	void	w_mk_double ( PWord *, int *, double );
+extern	void	w_get_double ( double *, PWord );
+extern	int	w_unify ( PWord, int, PWord, int );
+extern	int	w_rungoal ( PWord, PWord, int );
 
 /*
  * Declarations and prototypes for other related functions.
  */
 
 	/* from arith.c */
-extern	void	make_number		PARAMS( (PWord *, int *, double) );
-extern	void	make_numberx	PARAMS( (PWord *, int *, double, int) );
+extern	void	make_number		(PWord *, int *, double);
+extern	void	make_numberx	(PWord *, int *, double, int);
 	/* from gv.c */
-extern	PWord	gv_alloc	PARAMS( (void) );
-extern	int	gv_alloc_gvnum	PARAMS( (int) );
-extern	int	gv_isfree	PARAMS( (int) );
-extern	void	gv_free		PARAMS( (PWord) );
-extern	void	gv_get		PARAMS( (PWord *, int *, PWord) );
-extern	void	gv_set		PARAMS( (PWord, int, PWord) );
+extern	PWord	gv_alloc	(void);
+extern	int	gv_alloc_gvnum	(int);
+extern	int	gv_isfree	(int);
+extern	void	gv_free		(PWord);
+extern	void	gv_get		(PWord *, int *, PWord);
+extern	void	gv_set		(PWord, int, PWord);
 
 /* from assembly language (perhaps) */
-extern	int	_w_unify	PARAMS( (PWord, PWord) );
+extern	int	_w_unify	(PWord, PWord);
 
 
 /*
@@ -236,7 +236,7 @@ extern	int	_w_unify	PARAMS( (PWord, PWord) );
  * Heap and stack allocation function (see mem.c)
  */
 
-PWord *allocate_prolog_heap_and_stack PARAMS(( size_t ));
+PWord *allocate_prolog_heap_and_stack ( size_t );
 
 #ifdef __cplusplus
 }

--- a/core/alsp_src/port/disassem.c
+++ b/core/alsp_src/port/disassem.c
@@ -38,8 +38,8 @@ static struct _icode {
 };
 #undef ABMOP
 
-enum AbstractMachineOps decode_instr PARAMS(( Code ));
-int	display_instr	PARAMS( (enum AbstractMachineOps, Code *));
+enum AbstractMachineOps decode_instr ( Code );
+int	display_instr	(enum AbstractMachineOps, Code *);
 
 
 /*
@@ -199,7 +199,7 @@ display_instr(instr,ip)
 */
 
 #ifdef TRACEBWAM
-void tracewam	PARAMS(( Code * ));
+void tracewam	( Code * );
 
 int bwam_trace = 0;
 int bwam_trace_low = 0;

--- a/core/alsp_src/port/icode1.c
+++ b/core/alsp_src/port/icode1.c
@@ -101,20 +101,20 @@ static long sp_disp;
 		 (iidx >= 0 ? posic[iidx] : negic[-iidx-1]), \
 		 w,x,y,z);
 
-#define ICODE(macro,str,addr,obp) void addr PARAMS(( long, long, long, long ));
+#define ICODE(macro,str,addr,obp) void addr ( long, long, long, long );
 #include "icodedef.h"
 
-static	void	ic_illegal	PARAMS(( long, long, long, long ));
-static	void	ic_uiastr	PARAMS(( char * ));
-static	void	ic_p_const	PARAMS(( long, long, long ));
-static	void	ic_backpatch	PARAMS(( Code *, int ));
-static	void	addtosp		PARAMS(( long ));
+static	void	ic_illegal	( long, long, long, long );
+static	void	ic_uiastr	( char * );
+static	void	ic_p_const	( long, long, long );
+static	void	ic_backpatch	( Code *, int );
+static	void	addtosp		( long );
 
 #undef ICODE
 #define ICODE(macro,str,addr,obp) {addr},
 
 static struct {
-    void  (*doit) PARAMS(( long, long, long, long ));
+    void  (*doit) ( long, long, long, long );
 } instrs[] = {
 
 #include "icodedef.h"

--- a/core/alsp_src/port/icode2.c
+++ b/core/alsp_src/port/icode2.c
@@ -310,7 +310,7 @@ ic_install_no(buf, clausestart, nocatcher)
 void
 ic_install_builtin(ne, builtin)
     ntbl_entry *ne;
-    int   (*builtin) PARAMS(( void ));
+    int   (*builtin) ( void );
 {
     Code *oldptr = ic_ptr;
 

--- a/core/alsp_src/port/wam.c
+++ b/core/alsp_src/port/wam.c
@@ -35,17 +35,17 @@
 /*#include "dump_wam.h" */
 
 #ifdef TRACEBWAM
-extern	int tracewam	PARAMS(( Code * ));
+extern	int tracewam	( Code * );
 #endif
 
-	int	run_wam		PARAMS(( Code * ));
-static	int	wam_unify	PARAMS(( PWord *, PWord * ));
+	int	run_wam		( Code * );
+static	int	wam_unify	( PWord *, PWord * );
 
 #ifdef	Threaded
 Code  wam_instrs[W_NUM_OPS];	/* map from instruction number to label */
 #endif	/* Threaded */
 
-extern int trailed_mangle0 PARAMS((PWord,PWord,int,PWord,int));
+extern int trailed_mangle0 (PWord,PWord,int,PWord,int);
 
 #ifdef	IProfile
 
@@ -179,7 +179,7 @@ PWord *gr_SPB, *gr_HB, *gr_TR;
 #define	MMTCH(f) printf("   match is delay [f=%x[_%lu]]\n", 				\
 						  (int)f,(long)(((PWord *) f) - wm_heapbase));	   
 
-int ck_intvl_punch   PARAMS((PWord, PWord, int));
+int ck_intvl_punch   (PWord, PWord, int);
 
     /*-------------------------------------------------*
 	 |	ck_intvl_punch - used during variable binding,
@@ -1639,7 +1639,7 @@ CASE(W_OVJUMP):
 
 CASE(W_FOREIGN_JUMP):		/* foreign_jump dst */
 	    UNSHADOW_REGS;
-	    if (!((*(int (*)PARAMS((void))) *PWPTR(P + OPSIZE)) ())) {
+	    if (!((*(int (*)(void)) *PWPTR(P + OPSIZE)) ())) {
 		SHADOW_REGS;
 		DOFAIL;
 	    }
@@ -2399,7 +2399,7 @@ _w_unify(f1, f2)
  |
  |		installs a reference to G into R (R --> G)
  *---------------------------------------------------------------*/
-int     pbi_bind_vars           PARAMS(( void ));
+int     pbi_bind_vars           ( void );
 
 int
 pbi_bind_vars()
@@ -2428,7 +2428,7 @@ pbi_bind_vars()
 #if defined(INTCONSTR)
 #include "intrv.h"
 
-void plain_bind	PARAMS((PWord, PWord));
+void plain_bind	(PWord, PWord);
 
 void
 plain_bind(r, v)
@@ -2440,7 +2440,7 @@ plain_bind(r, v)
 
 
 
-void bind_point_unfreeze	PARAMS((PWord *,int *,double,int));
+void bind_point_unfreeze	(PWord *,int *,double,int);
 void
 bind_point_unfreeze(r,t,pv,k)
 	PWord *r;

--- a/core/alsp_src/unix/unixio.c
+++ b/core/alsp_src/unix/unixio.c
@@ -544,8 +544,8 @@ pmkdir()
 
 #define STAT stat_with_timeout
 
-static	void	stat_timedout		PARAMS(( void ));
-static	int	stat_with_timeout	PARAMS(( const char *, struct stat * ));
+static	void	stat_timedout		( void );
+static	int	stat_with_timeout	( const char *, struct stat * );
 
 static void
 stat_timedout()
@@ -834,7 +834,7 @@ canonicalize_pathname()
 
 long 
 get_file_modified_time(fname)
-    CONST char *fname;
+    const char *fname;
 {
     struct stat buf;
 
@@ -850,7 +850,7 @@ get_file_modified_time(fname)
  */
 int
 isdir(fname)
-    CONST char *fname;
+    const char *fname;
 {
     struct stat buf;
 


### PR DESCRIPTION
Officially require a minimum of ANSI-C89-C90 Standard C. Truth be told,
the source has had bits of C89 and even C99 in it for some time.