### PR TITLE
Reorganize, reduce and document filepath builtins.

### DIFF
--- a/core/alsp_src/builtins/filepath.pro
+++ b/core/alsp_src/builtins/filepath.pro
@@ -272,6 +272,28 @@ pathPlusFilesList([File | SourceFilesList], Path,
 	pathPlusFile(Path,File,XFile),
 	pathPlusFilesList(SourceFilesList, Path, ExtendedFilesList).
 
+/*!---------------------------------------------------------------------
+ |      path_elements/2
+ |      path_elements(Path, Elements)
+ |      path_elements(+/-, +/-)
+ |
+ |      - compose/decompose a file system path from/to its elements
+ |
+ |      If Path is a file system path to a file or directory, then
+ |      this call decomposes Path into a list of it's minimal elements,
+ |      and unifies that list with Elements.  If Path is uninstantiated
+ |      and Elements is a list of path elements (some of which may consist
+ |      of more than a single element), this call composes the list
+ |      Elements into an atom and unifies that atom with Path.
+ |
+ | Examples
+ |      ?- path_elements('mom/kids/foo.pro', E).
+ |      E=[mom,kids,'foo.pro']
+ |      ?- path_elements(P, [mom,kids,'foo.pro']).
+ |      P='mom/kids/foo.pro'
+ |      ?- path_elements(P, ['mom/dad',kids,'foo.pro']).
+ |      P='mom/dad/kids/foo.pro'
+ *!--------------------------------------------------------------------*/
 path_elements(Path, Elements) :-
 	var(Path),
 	!,
@@ -279,8 +301,23 @@ path_elements(Path, Elements) :-
 path_elements(Path, Elements) :-
 	split_path(Path, Elements).
 
-
-
+/*!---------------------------------------------------------------------
+ |      path_type/2
+ |      path_type(Path, Type)
+ |      path_type(+, +)
+ |
+ |      - determines the type (absolute,relative) of a file system path
+ |
+ |      If Path is a file system path, unifies Type with 'absolute' or
+ |      'relative' according to the type of Path.  Utilized by
+ |      is_absolute_path/1 above.
+ |
+ | Examples
+ |      ?- path_type('mom/kids/foo.pro', T).
+ |      T=relative
+ |      ?- path_type('/mom/kids/foo.pro', T).
+ |      T=absolute
+ *!--------------------------------------------------------------------*/
 path_type(Path, Type) :-
 	sys_env(OS, _, _),
 	!,

--- a/core/alsp_src/builtins/filepath.pro
+++ b/core/alsp_src/builtins/filepath.pro
@@ -1,35 +1,35 @@
 /*=================================================================
- |              filepath.pro
- |      Copyright (c) 1991-96,2020 Applied Logic Systems, Inc.
- |              Group: File System
- |              DocTitle: file_extension/3
+ |		filepath.pro
+ |	Copyright (c) 1991-96 Applied Logic Systems, Inc.
+ |		Group: File System
+ |		DocTitle: file_extension/3
  |
  |
- |      Abstract handling of building and decomposing file names with paths.
+ |	Abstract handling of building and decomposing file names with paths.
  |
  |  Author: Chuck Houpt, Ken Bowen
- |  Date:       May, 1991
+ |  Date:	May, 1991
  |  Revised with "root" terminology: October,1991
  |
- |      Terminology
- |      -----------
- |              File -- the name part of a file designator, as:
- |                                      zip in 'zip.pro' ;
- |              Extension -- the extension part of a file designator, as:
- |                                      pro in 'zip.pro' ;
- |              Full file name -- name part plus extension (if any), as:
- |                                      'zip.pro',    zap (no extension)
- |              (Sub)path -- sequence of names of (sub)directories, each
- |                                      a subdirectory of the preceeding, as:
- |                                      foo/bar/silly
- |                                      foo\bar\silly
- |              Root -- the file root symbol, combined with a "disk" indicator,
- |                                      if any, as:
- |                                      'c:\'
- |                                      '\'
- |              Parent (of a file,directory) -- the directory containing
- |                                      a given file or (sub)directory, as:
- |                                      mom/kid.txt   mom is parent of kid.txt
+ |	Terminology
+ |	-----------
+ |		File -- the name part of a file designator, as:
+ |					zip in 'zip.pro' ;
+ |		Extension -- the extension part of a file designator, as:
+ |					pro in 'zip.pro' ;
+ |		Full file name -- name part plus extension (if any), as:
+ |					'zip.pro',    zap (no extension)
+ |		(Sub)path -- sequence of names of (sub)directories, each
+ |					a subdirectory of the preceeding, as:
+ |					foo/bar/silly
+ |					foo\bar\silly
+ |		Root -- the file root symbol, combined with a "disk" indicator,
+ |					if any, as:
+ |					'c:\'
+ |					'\'
+ |		Parent (of a file,directory) -- the directory containing
+ |					a given file or (sub)directory, as:
+ |					mom/kid.txt   mom is parent of kid.txt
  |
  |  Revised to use sub_atom, atom_concat, etc: November 1993 by K. Buettner
  *================================================================*/
@@ -50,29 +50,29 @@ export directory_self/1.
 export parent_path/1.
 
 /*!---------------------------------------------------------------------
- |      file_extension/3
- |      file_extension(FullName, Name, Ext)
- |      file_extension(+/-, +/-, +/-)
+ |	file_extension/3
+ |	file_extension(FullName, Name, Ext)
+ |	file_extension(+/-, +/-, +/-)
  |
- |      - Access or add the extension for a filename.
+ |	- Access or add the extension for a filename.
  |
- |      If FullName is instantiated, decomposes it to yield the
- |      underlying Filename (unified with Name)  and extension (unified
- |      with Ext.  If FullName is instantiated but has no extension, then
- |      Name is unified with FullName and Ext is unified with ''.
- |      If FullName is uninstantiated and both Name, Ext are instantiated,
- |      composes the filename plus extension out of Name, Ext and unifies
- |      that with FullName.
+ |	If FullName is instantiated, decomposes it to yield the 
+ |	underlying Filename (unified with Name)  and extension (unified
+ |	with Ext.  If FullName is instantiated but has no extension, then
+ |	Name is unified with FullName and Ext is unified with ''.
+ |	If FullName is uninstantiated and both Name, Ext are instantiated, 
+ |	composes the filename plus extension out of Name, Ext and unifies 
+ |	that with FullName.
  |
  | Examples
- |      ?- file_extension(foo, Name1, Ext1).
- |      Name1=foo
- |      Ext1=''
- |      ?- file_extension('foo.pro', Name2, Ext2).
- |      Name2=foo
- |      Ext2=pro
- |      ?- file_extension(FullName, bar, pro).
- |      FullName='bar.pro'
+ |	?- file_extension(foo, Name1, Ext1).
+ |	Name1=foo 
+ |	Ext1='' 
+ |	?- file_extension('foo.pro', Name2, Ext2).
+ |	Name2=foo 
+ |	Ext2=pro 
+ |	?- file_extension(FullName, bar, pro).
+ |	FullName='bar.pro' 
  *!--------------------------------------------------------------------*/
 file_extension(FullName, Name, Ext) :-
 	nonvar(FullName),
@@ -98,32 +98,32 @@ file_extension(FullName, FileName, Ext) :-
 	atom_concat(FileNameDot, Ext, FullName).
 
 /*!---------------------------------------------------------------------
- |      path_directory_tail/3
- |      path_directory_tail(Path, Directory, Tail)
- |      path_directory_tail(+/-, +/-, +/-)
+ |	path_directory_tail/3
+ |	path_directory_tail(Path, Directory, Tail)
+ |	path_directory_tail(+/-, +/-, +/-)
  |
- |      - Compose or decompose a path to a file in a directory.
+ |	- Compose or decompose a path to a file in a directory.
  |
- |      If Path is uninstantiated, then joins Directory with Tail, and
- |      unifies the result with Path.
- |      If Path is instantiated, removes the last element from Path,
- |      leaving Not-Last, unifies the last element with Tail, and:
- |      if Not-Last is empty, unifies Directory with '.', else
- |      unifies Directory with Not-Last.
+ |	If Path is uninstantiated, then joins Directory with Tail, and
+ |	unifies the result with Path.
+ |	If Path is instantiated, removes the last element from Path,
+ |	leaving Not-Last, unifies the last element with Tail, and: 
+ |	if Not-Last is empty, unifies Directory with '.', else
+ |	unifies Directory with Not-Last.
  |
  | Examples
- |      ?- path_directory_tail(Path, 'mom/kids', 'bar/zip.pro').
- |      Path == 'mom/kids/bar/zip.pro'
- |      ?- path_directory_tail('mom/kids/bar/zip.pro', 'mom/kids/bar', Tail).
- |      Tail == 'zip.pro'
- |      ?- path_directory_tail('mom/kids/bar/zip.pro', Directory, 'zip.pro').
- |      Directory == 'mom/kids/bar'
- |      ?- path_directory_tail('mom/kids/bar/zip.pro', Directory, Tail).
- |      Directory == 'mom/kids/bar'
- |      Tail='zip.pro'
- |      ?- path_directory_tail('zip.pro', Directory, Tail).
- |      Directory='.'
- |      Tail='zip.pro'
+ |	?- path_directory_tail(Path, 'mom/kids', 'bar/zip.pro').
+ |	Path == 'mom/kids/bar/zip.pro'
+ |	?- path_directory_tail('mom/kids/bar/zip.pro', 'mom/kids/bar', Tail).
+ |	Tail == 'zip.pro'
+ |	?- path_directory_tail('mom/kids/bar/zip.pro', Directory, 'zip.pro').
+ |	Directory == 'mom/kids/bar'
+ |	?- path_directory_tail('mom/kids/bar/zip.pro', Directory, Tail).
+ |	Directory == 'mom/kids/bar'
+ |	Tail='zip.pro'
+ |	?- path_directory_tail('zip.pro', Directory, Tail).
+ |	Directory='.'
+ |	Tail='zip.pro'
  *!--------------------------------------------------------------------*/
 path_directory_tail(Path, Directory, Tail) :-
 	var(Path),
@@ -136,36 +136,36 @@ path_directory_tail(Path, Directory, Tail) :-
 	(DirElements = [] -> directory_self(Directory) ; join_path(DirElements, Directory)).
 
 /*!---------------------------------------------------------------------
- |      is_absolute_path/1
- |      is_absolute_path(Path)
- |      is_absolute_path(Path)
+ |	is_absolute_path/1
+ |	is_absolute_path(Path)
+ |	is_absolute_path(Path)
  |
- |      - Determines whether Path begins at the file system root.
+ |	- Determines whether Path begins at the file system root.
  |
- |      Succeeds if Path begins at the file system root, fails otherwise.
+ |	Succeeds if Path begins at the file system root, fails otherwise.
  |
  | Examples
- |      ?- is_absolute_path('/foo/bar').
- |      yes.
+ |	?- is_absolute_path('/foo/bar').
+ |	yes.
  |      ?- not(is_absolute_path('foo/bar')).
- |      yes.
+ |	yes.
  *!--------------------------------------------------------------------*/
 is_absolute_path(Path) :-
 	path_type(Path, PathType),
 	PathType \= relative.
 
 /*!---------------------------------------------------------------------
- |      tilda_expand/2
- |      tilda_expand(TildaPath, Path)
- |      tilda_expand(+, -)
+ |	tilda_expand/2
+ |	tilda_expand(TildaPath, Path)
+ |	tilda_expand(+, -)
  |
- |      - Expands a tilda-path to an absolute file system path.
+ | 	- Expands a tilda-path to an absolute file system path.
  |
- |      Replaces the leading tilde (~) appropriately.
+ |	Replaces the leading tilde (~) appropriately.
  |
  | Examples
- |      ?- tilda_expand('~/foo/bar.pro', Path).
- |      Path='/Users/mike/foo/bar.pro'
+ |	?- tilda_expand('~/foo/bar.pro', Path).
+ |	Path='/Users/mike/foo/bar.pro'
  *!--------------------------------------------------------------------*/
 tilda_expand(TildaPath, Path) :-
 	sub_atom(TildaPath, 0, 1, _, '~'),
@@ -178,16 +178,16 @@ tilda_expand(TildaPath, Path) :-
 tilda_expand(Path, Path).
 
 /*!---------------------------------------------------------------------
- |      make_change_cwd/1
- |      make_change_cwd(P)
- |      make_change_cwd(+)
+ |	make_change_cwd/1
+ |	make_change_cwd(P)
+ |	make_change_cwd(+)
  |
- |      - Creates path P to a directory, as needed, and changes to it.
+ |	- Creates path P to a directory, as needed, and changes to it.
  |
- |      If P is instantiated to a legal path to a directory, then:
- |      If the directory exists, executes change_cwd(P).
- |      Otherwise, creates the directory, including all intermediate
- |      directories, and then executes change_cwd(P).
+ |	If P is instantiated to a legal path to a directory, then: 
+ |	If the directory exists, executes change_cwd(P).  
+ |	Otherwise, creates the directory, including all intermediate
+ |	directories, and then executes change_cwd(P).
  *!--------------------------------------------------------------------*/
 make_change_cwd(P)
 	:-
@@ -215,24 +215,24 @@ make_path_segments([E | PElts], IS)
 	make_path_segments(PElts, [E | IS]).
 
 /*!---------------------------------------------------------------------
- |      pathPlusFile/3
- |      pathPlusFile(Path, File, PathAndFile)
- |      pathPlusFile(+/-, +/-, +/-)
+ |	pathPlusFile/3
+ |	pathPlusFile(Path, File, PathAndFile)
+ |	pathPlusFile(+/-, +/-, +/-)
  |
- |      - Compose/decompose a path with a terminating file.
+ |	- Compose/decompose a path with a terminating file.
  |
- |      If PathAndFile is uninstantiated, adds File to the end of
- |      Path and unifies that with PathAndFile.  If PathAndFile is
- |      instantiated, removes the final element from PathAndFile,
- |      unifies the remainder with Path, and unifies that last
- |      element with File.
+ |	If PathAndFile is uninstantiated, adds File to the end of 
+ |	Path and unifies that with PathAndFile.  If PathAndFile is
+ |	instantiated, removes the final element from PathAndFile,
+ |	unifies the remainder with Path, and unifies that last
+ |	element with File.
  |
  | Examples
- |      ?- pathPlusFile('foo/bar', 'zip.pro', PF).
- |      PF='foo/bar/zip.pro'
- |      ?- pathPlusFile(P,F,'foo/bar/zip.pro').
- |      P='foo/bar'
- |      F='zip.pro'
+ |	?- pathPlusFile('foo/bar', 'zip.pro', PF).
+ |	PF='foo/bar/zip.pro' 
+ |	?- pathPlusFile(P,F,'foo/bar/zip.pro').
+ |	P='foo/bar' 
+ |	F='zip.pro'
  *!--------------------------------------------------------------------*/
 pathPlusFile(Path, File, PathAndFile)
 	:-
@@ -251,20 +251,20 @@ pathPlusFile(Path, File, PathAndFile)
 	join_path(PathElts, Path).
 
 /*!---------------------------------------------------------------------
- |      pathPlusFilesList/3.
- |      pathPlusFilesList(SourceFilesList, Path, ExtendedFilesList)
- |      pathPlusFilesList(+, +, -)
+ |	pathPlusFilesList/3.
+ |	pathPlusFilesList(SourceFilesList, Path, ExtendedFilesList)
+ |	pathPlusFilesList(+, +, -)
  |
- |      - attaches a path to each of a list of file names
+ |	- attaches a path to each of a list of file names
  |
- |      If SourceFilesList is list of items denoting file names, and
- |      if Path denotes a path, creates a list of atoms which consists
- |      of the Path prepended to each of the file names.  Functionally
- |      identical to prefix_dir/3 in library file miscatom.pro.
+ |	If SourceFilesList is list of items denoting file names, and
+ |	if Path denotes a path, creates a list of atoms which consists 
+ |	of the Path prepended to each of the file names.  Functionally
+ |	identical to prefix_dir/3 in library file miscatom.pro.
  |
  | Examples
- |      ?- pathPlusFilesList(['foo.pro','bar.pro','zip.pro'], 'mom/kids', EFL).
- |      EFL=['mom/kids/foo.pro','mom/kids/bar.pro','mom/kids/zip.pro']
+ |	?- pathPlusFilesList(['foo.pro','bar.pro','zip.pro'], 'mom/kids', EFL).
+ |	EFL=['mom/kids/foo.pro','mom/kids/bar.pro','mom/kids/zip.pro']
  *!--------------------------------------------------------------------*/
 pathPlusFilesList([], _, []).
 pathPlusFilesList([File | SourceFilesList], Path, 
@@ -273,26 +273,26 @@ pathPlusFilesList([File | SourceFilesList], Path,
 	pathPlusFilesList(SourceFilesList, Path, ExtendedFilesList).
 
 /*!---------------------------------------------------------------------
- |      path_elements/2
- |      path_elements(Path, Elements)
- |      path_elements(+/-, +/-)
+ |	path_elements/2
+ |	path_elements(Path, Elements)
+ |	path_elements(+/-, +/-)
  |
- |      - compose/decompose a file system path from/to its elements
+ |	- compose/decompose a file system path from/to its elements
  |
- |      If Path is a file system path to a file or directory, then
- |      this call decomposes Path into a list of it's minimal elements,
- |      and unifies that list with Elements.  If Path is uninstantiated
- |      and Elements is a list of path elements (some of which may consist
- |      of more than a single element), this call composes the list
- |      Elements into an atom and unifies that atom with Path.
+ | 	If Path is a file system path to a file or directory, then
+ |	this call decomposes Path into a list of it's minimal elements, 
+ |	and unifies that list with Elements.  If Path is uninstantiated 
+ |	and Elements is a list of path elements (some of which may consist 
+ |	of more than a single element), this call composes the list
+ |	Elements into an atom and unifies that atom with Path.
  |
  | Examples
- |      ?- path_elements('mom/kids/foo.pro', E).
- |      E=[mom,kids,'foo.pro']
- |      ?- path_elements(P, [mom,kids,'foo.pro']).
- |      P='mom/kids/foo.pro'
- |      ?- path_elements(P, ['mom/dad',kids,'foo.pro']).
- |      P='mom/dad/kids/foo.pro'
+ |	?- path_elements('mom/kids/foo.pro', E).
+ |	E=[mom,kids,'foo.pro'] 
+ |	?- path_elements(P, [mom,kids,'foo.pro']).
+ |	P='mom/kids/foo.pro' 
+ |	?- path_elements(P, ['mom/dad',kids,'foo.pro']).
+ |	P='mom/dad/kids/foo.pro' 
  *!--------------------------------------------------------------------*/
 path_elements(Path, Elements) :-
 	var(Path),
@@ -302,21 +302,21 @@ path_elements(Path, Elements) :-
 	split_path(Path, Elements).
 
 /*!---------------------------------------------------------------------
- |      path_type/2
- |      path_type(Path, Type)
- |      path_type(+, +)
+ |	path_type/2
+ |	path_type(Path, Type)
+ |	path_type(+, +)
  |
- |      - determines the type (absolute,relative) of a file system path
+ |	- determines the type (absolute,relative) of a file system path
  |
- |      If Path is a file system path, unifies Type with 'absolute' or
- |      'relative' according to the type of Path.  Utilized by
- |      is_absolute_path/1 above.
- |
+ |	If Path is a file system path, unifies Type with 'absolute' or
+ |	'relative' according to the type of Path.  Utilized by
+ |	is_absolute_path/1 above.	
+ | 
  | Examples
- |      ?- path_type('mom/kids/foo.pro', T).
- |      T=relative
- |      ?- path_type('/mom/kids/foo.pro', T).
- |      T=absolute
+ |	?- path_type('mom/kids/foo.pro', T).
+ |	T=relative 
+ |	?- path_type('/mom/kids/foo.pro', T).
+ |	T=absolute 
  *!--------------------------------------------------------------------*/
 path_type(Path, Type) :-
 	sys_env(OS, _, _),
@@ -350,19 +350,19 @@ win32_path_type(Path, volume_relative) :-
 win32_path_type(Path, relative).
 
 /*!---------------------------------------------------------------------
- |      split_path/2
- |      split_path(Path, List)
- |      split_path(+, -)
+ | 	split_path/2
+ | 	split_path(Path, List)
+ | 	split_path(+, -)
  |
- |      - decomposes Path into List of elements
+ |	- decomposes Path into List of elements
  |
- |      If Path is a file system path, decomposes Path into a List
- |      of it's minimal elements, and unifies that list with List
- |      in an OS-independent manner. Utilized by path_elements/2 above.
+ |	If Path is a file system path, decomposes Path into a List
+ |	of it's minimal elements, and unifies that list with List
+ |	in an OS-independent manner. Utilized by path_elements/2 above.
  |
  | Examples
- |      ?- split_path('mom/kids/foo.pro', List).
- |      List=[mom,kids,'foo.pro']
+ |	?- split_path('mom/kids/foo.pro', List).
+ |	List=[mom,kids,'foo.pro'] 
  *!--------------------------------------------------------------------*/
 split_path(Path, List) :-
 	sub_atom(Path,0,1,_,'{'),
@@ -380,18 +380,18 @@ split_path(Path, List) :-
 	split_path(OS, Path, List).
 
 /*!---------------------------------------------------------------------
- |      join_path/2
- |      join_path(List, Path)
- |      join_path(+, -)
+ |	join_path/2
+ |	join_path(List, Path)
+ |	join_path(+, -)
+ | 
+ |	- composes Path from a List of elements
  |
- |      - composes Path from a List of elements
- |
- |      If List consists of atoms representing elements of a file system
- |      path, composes Path out of List in an OS-independent manner.
+ |	If List consists of atoms representing elements of a file system
+ |	path, composes Path out of List in an OS-independent manner.
  |
  | Examples
- |      ?- join_path(['mom/dad',kids,'foo.pro'], Path),
- |      Path='mom/dad/kids/foo.pro'.
+ |	?- join_path(['mom/dad',kids,'foo.pro'], Path),
+ |	Path='mom/dad/kids/foo.pro'.
  *!--------------------------------------------------------------------*/
 join_path(List, Path) :-
 	sys_env(OS, _, _),
@@ -589,7 +589,7 @@ win32_join_path(A, B, Path) :-
 	atom_concat(AHead, B, Path).
 
 
-% Utility routine.
+% Utility routine:
 
 find_sub(_, _, _, []) :- !, fail.
 find_sub(Atom, Before, After, [SubAtom | Tail]) :-
@@ -618,20 +618,20 @@ rev_sub_atom(Atom, Before, Length, After, SubAtom) :-
 rev_sub_atom(_, _, _, _, _) :- fail.
 
 /*!---------------------------------------------------------------------
- |      directory_self/1
- |      directory_self(Self)
- |      directory_self(+/-)
+ |	directory_self/1
+ |	directory_self(Self)
+ |	directory_self(+/-)
  |
- |      - Returns an atom representing a relative path to the current directory.
- |      
- |      Unifies Self with an atom representing the minimal relative path
- |      to the current directory, in an OS-independent manner.
- |      
+ |	- Returns an atom representing a relative path to the current directory.
+ |
+ |	Unifies Self with an atom representing the minimal relative path
+ |	to the current directory, in an OS-independent manner.
+ |
  | Examples
- |      ?- directory_self(Self).
- |      Self='.'
- |      ?- directory_self('.').
- |      yes.
+ |	?- directory_self(Self).
+ |	Self='.' 
+ |	?- directory_self('.').
+ |	yes. 
  *!--------------------------------------------------------------------*/
 directory_self(Self) :-
 	sys_env(OS, _, _),
@@ -644,20 +644,20 @@ directory_self(mswin32, '.').
 directory_self(win32, '.').
 
 /*!---------------------------------------------------------------------
- |      parent_path/1
- |      parent_path(PP)
- |      parent_path(+/-)
- |      
- |      - Returns an atom representing a relative path to the parent of the current directory.
+ |	parent_path/1
+ |	parent_path(PP)
+ |	parent_path(+/-)
  |
- |      Unifies PP with an atom representing the minimal relative path
- |      to the parent of the current directory, in an OS-independent manner.
- |      
+ |	- Returns an atom representing a relative path to the parent of the current directory.
+ |
+ |	Unifies PP with an atom representing the minimal relative path
+ |	to the parent of the current directory, in an OS-independent manner.
+ |
  | Examples
- |      ?- parent_path(PP).
- |      PP='..'
- |      ?- parent_path('..').
- |      yes.
+ |	?- parent_path(PP).
+ |	PP='..' 
+ |	?- parent_path('..').
+ |	yes.	
  *!--------------------------------------------------------------------*/
 parent_path(PP) :-
 	sys_env(OS, _, _),

--- a/core/alsp_src/builtins/filepath.pro
+++ b/core/alsp_src/builtins/filepath.pro
@@ -1,52 +1,53 @@
 /*=================================================================
- |		filepath.pro
- |	Copyright (c) 1991-96 Applied Logic Systems, Inc.
+ |              filepath.pro
+ |      Copyright (c) 1991-96,2020 Applied Logic Systems, Inc.
+ |              Group: File System
+ |              DocTitle: file_extension/3
  |
- |	Abstract handling of building and decomposing file names with paths.
  |
- |  Author: Ken Bowen
- |  Date:	May, 1991
- |	Revised with "root" terminology: October,1991
+ |      Abstract handling of building and decomposing file names with paths.
  |
- |	Terminology
- |	-----------
- |		File -- the name part of a file designator, as:
- |					zip in 'zip.pro' ;
- |		Extension -- the extension part of a file designator:
- |					pro in 'zip.pro' ;
- |		Full file name -- name part plus extension (if any):
- |					'zip.pro',    zip
- |		(Sub)path -- sequence of names of (sub)directories, each
- |					a subdirectory of the preceeding:
- |					foo/bar/silly
- |					foo\bar\silly
- |		Root -- the file root symbol, combined with a "disk" indicator,
- |			if any:
- |				'c:\'
- |				'\'
- |	Revised to use sub_atom, atom_concat, etc: November 1993 by K. Buettner
+ |  Author: Chuck Houpt, Ken Bowen
+ |  Date:       May, 1991
+ |  Revised with "root" terminology: October,1991
+ |
+ |      Terminology
+ |      -----------
+ |              File -- the name part of a file designator, as:
+ |                                      zip in 'zip.pro' ;
+ |              Extension -- the extension part of a file designator, as:
+ |                                      pro in 'zip.pro' ;
+ |              Full file name -- name part plus extension (if any), as:
+ |                                      'zip.pro',    zap (no extension)
+ |              (Sub)path -- sequence of names of (sub)directories, each
+ |                                      a subdirectory of the preceeding, as:
+ |                                      foo/bar/silly
+ |                                      foo\bar\silly
+ |              Root -- the file root symbol, combined with a "disk" indicator,
+ |                                      if any, as:
+ |                                      'c:\'
+ |                                      '\'
+ |              Parent (of a file,directory) -- the directory containing
+ |                                      a given file or (sub)directory, as:
+ |                                      mom/kid.txt   mom is parent of kid.txt
+ |
+ |  Revised to use sub_atom, atom_concat, etc: November 1993 by K. Buettner
  *================================================================*/
 module builtins.
 
 export file_extension/3.
-export path_elements/2.
 export path_directory_tail/3.
 export is_absolute_path/1.
-%export is_absolute_path/2.
-export path_type/2.
-export path_type/3.
-export split_path/2.
-export split_path/3.
-export join_path/2.
-export join_path/3.
 export tilda_expand/2.
-export directory_self/1.
-export directory_self/2.
-export parent_path/1.
-export parent_path/2.
+export make_change_cwd/1.
 export pathPlusFile/3.
 export pathPlusFilesList/3.
-export make_change_cwd/1.
+export path_elements/2.
+export path_type/2.
+export split_path/2.
+export join_path/2.
+export directory_self/1.
+export parent_path/1.
 
 file_extension(FullName, Name, Ext) :-
 	nonvar(FullName),

--- a/core/alsp_src/builtins/filepath.pro
+++ b/core/alsp_src/builtins/filepath.pro
@@ -97,6 +97,34 @@ file_extension(FullName, FileName, Ext) :-
 	atom_concat(FileName,'.',FileNameDot),
 	atom_concat(FileNameDot, Ext, FullName).
 
+/*!---------------------------------------------------------------------
+ |      path_directory_tail/3
+ |      path_directory_tail(Path, Directory, Tail)
+ |      path_directory_tail(+/-, +/-, +/-)
+ |
+ |      - Compose or decompose a path to a file in a directory.
+ |
+ |      If Path is uninstantiated, then joins Directory with Tail, and
+ |      unifies the result with Path.
+ |      If Path is instantiated, removes the last element from Path,
+ |      leaving Not-Last, unifies the last element with Tail, and:
+ |      if Not-Last is empty, unifies Directory with '.', else
+ |      unifies Directory with Not-Last.
+ |
+ | Examples
+ |      ?- path_directory_tail(Path, 'mom/kids', 'bar/zip.pro').
+ |      Path == 'mom/kids/bar/zip.pro'
+ |      ?- path_directory_tail('mom/kids/bar/zip.pro', 'mom/kids/bar', Tail).
+ |      Tail == 'zip.pro'
+ |      ?- path_directory_tail('mom/kids/bar/zip.pro', Directory, 'zip.pro').
+ |      Directory == 'mom/kids/bar'
+ |      ?- path_directory_tail('mom/kids/bar/zip.pro', Directory, Tail).
+ |      Directory == 'mom/kids/bar'
+ |      Tail='zip.pro'
+ |      ?- path_directory_tail('zip.pro', Directory, Tail).
+ |      Directory='.'
+ |      Tail='zip.pro'
+ *!--------------------------------------------------------------------*/
 path_directory_tail(Path, Directory, Tail) :-
 	var(Path),
 	!,

--- a/core/alsp_src/builtins/filepath.pro
+++ b/core/alsp_src/builtins/filepath.pro
@@ -154,6 +154,19 @@ is_absolute_path(Path) :-
 	path_type(Path, PathType),
 	PathType \= relative.
 
+/*!---------------------------------------------------------------------
+ |      tilda_expand/2
+ |      tilda_expand(TildaPath, Path)
+ |      tilda_expand(+, -)
+ |
+ |      - Expands a tilda-path to an absolute file system path.
+ |
+ |      Replaces the leading tilde (~) appropriately.
+ |
+ | Examples
+ |      ?- tilda_expand('~/foo/bar.pro', Path).
+ |      Path='/Users/mike/foo/bar.pro'
+ *!--------------------------------------------------------------------*/
 tilda_expand(TildaPath, Path) :-
 	sub_atom(TildaPath, 0, 1, _, '~'),
 	split_path(TildaPath, [Head | Rest]),
@@ -164,6 +177,18 @@ tilda_expand(TildaPath, Path) :-
 	(Home = '' -> Path = TildaPath ; join_path([Home | Rest], Path)).
 tilda_expand(Path, Path).
 
+/*!---------------------------------------------------------------------
+ |      make_change_cwd/1
+ |      make_change_cwd(P)
+ |      make_change_cwd(+)
+ |
+ |      - Creates path P to a directory, as needed, and changes to it.
+ |
+ |      If P is instantiated to a legal path to a directory, then:
+ |      If the directory exists, executes change_cwd(P).
+ |      Otherwise, creates the directory, including all intermediate
+ |      directories, and then executes change_cwd(P).
+ *!--------------------------------------------------------------------*/
 make_change_cwd(P)
 	:-
 	exists_file(P),

--- a/core/alsp_src/builtins/filepath.pro
+++ b/core/alsp_src/builtins/filepath.pro
@@ -617,7 +617,22 @@ rev_sub_atom(Atom, Before, Length, After, SubAtom) :-
 	(Before = LBefore, After = LAfter)).
 rev_sub_atom(_, _, _, _, _) :- fail.
 
-
+/*!---------------------------------------------------------------------
+ |      directory_self/1
+ |      directory_self(Self)
+ |      directory_self(+/-)
+ |
+ |      - Returns an atom representing a relative path to the current directory.
+ |      
+ |      Unifies Self with an atom representing the minimal relative path
+ |      to the current directory, in an OS-independent manner.
+ |      
+ | Examples
+ |      ?- directory_self(Self).
+ |      Self='.'
+ |      ?- directory_self('.').
+ |      yes.
+ *!--------------------------------------------------------------------*/
 directory_self(Self) :-
 	sys_env(OS, _, _),
 	!,
@@ -628,6 +643,22 @@ directory_self(macos, ':').
 directory_self(mswin32, '.').
 directory_self(win32, '.').
 
+/*!---------------------------------------------------------------------
+ |      parent_path/1
+ |      parent_path(PP)
+ |      parent_path(+/-)
+ |      
+ |      - Returns an atom representing a relative path to the parent of the current directory.
+ |
+ |      Unifies PP with an atom representing the minimal relative path
+ |      to the parent of the current directory, in an OS-independent manner.
+ |      
+ | Examples
+ |      ?- parent_path(PP).
+ |      PP='..'
+ |      ?- parent_path('..').
+ |      yes.
+ *!--------------------------------------------------------------------*/
 parent_path(PP) :-
 	sys_env(OS, _, _),
 	!,
@@ -637,7 +668,5 @@ parent_path(unix, '..').
 parent_path(macos, '::').
 parent_path(mswin32, '..').
 parent_path(win32, '..').
-
-
 
 endmod.

--- a/core/alsp_src/builtins/filepath.pro
+++ b/core/alsp_src/builtins/filepath.pro
@@ -349,7 +349,21 @@ win32_path_type(Path, volume_relative) :-
 	!.
 win32_path_type(Path, relative).
 
-
+/*!---------------------------------------------------------------------
+ |      split_path/2
+ |      split_path(Path, List)
+ |      split_path(+, -)
+ |
+ |      - decomposes Path into List of elements
+ |
+ |      If Path is a file system path, decomposes Path into a List
+ |      of it's minimal elements, and unifies that list with List
+ |      in an OS-independent manner. Utilized by path_elements/2 above.
+ |
+ | Examples
+ |      ?- split_path('mom/kids/foo.pro', List).
+ |      List=[mom,kids,'foo.pro']
+ *!--------------------------------------------------------------------*/
 split_path(Path, List) :-
 	sub_atom(Path,0,1,_,'{'),
 	!,
@@ -364,7 +378,21 @@ split_path(Path, List) :-
 	sys_env(OS, _, _),
 	!,
 	split_path(OS, Path, List).
-	
+
+/*!---------------------------------------------------------------------
+ |      join_path/2
+ |      join_path(List, Path)
+ |      join_path(+, -)
+ |
+ |      - composes Path from a List of elements
+ |
+ |      If List consists of atoms representing elements of a file system
+ |      path, composes Path out of List in an OS-independent manner.
+ |
+ | Examples
+ |      ?- join_path(['mom/dad',kids,'foo.pro'], Path),
+ |      Path='mom/dad/kids/foo.pro'.
+ *!--------------------------------------------------------------------*/
 join_path(List, Path) :-
 	sys_env(OS, _, _),
 	join_path(OS, List, Path).

--- a/core/alsp_src/builtins/filepath.pro
+++ b/core/alsp_src/builtins/filepath.pro
@@ -214,6 +214,26 @@ make_path_segments([E | PElts], IS)
 	(exists_file(SIP) -> true ; make_subdir(SIP)),
 	make_path_segments(PElts, [E | IS]).
 
+/*!---------------------------------------------------------------------
+ |      pathPlusFile/3
+ |      pathPlusFile(Path, File, PathAndFile)
+ |      pathPlusFile(+/-, +/-, +/-)
+ |
+ |      - Compose/decompose a path with a terminating file.
+ |
+ |      If PathAndFile is uninstantiated, adds File to the end of
+ |      Path and unifies that with PathAndFile.  If PathAndFile is
+ |      instantiated, removes the final element from PathAndFile,
+ |      unifies the remainder with Path, and unifies that last
+ |      element with File.
+ |
+ | Examples
+ |      ?- pathPlusFile('foo/bar', 'zip.pro', PF).
+ |      PF='foo/bar/zip.pro'
+ |      ?- pathPlusFile(P,F,'foo/bar/zip.pro').
+ |      P='foo/bar'
+ |      F='zip.pro'
+ *!--------------------------------------------------------------------*/
 pathPlusFile(Path, File, PathAndFile)
 	:-
 	var(PathAndFile),
@@ -230,18 +250,22 @@ pathPlusFile(Path, File, PathAndFile)
 	dreverse(RevPathElts, PathElts),
 	join_path(PathElts, Path).
 
-/*!-------------------------------------------------------*
-	pathPlusFilesList/3.
-	pathPlusFilesList(SourceFilesList, Path, ExtendedFilesList)
-	pathPlusFilesList(+, +, -)
-
-	- attaches a path to each of a list of file names
-
-	If SourceFilesList is list of items denoting files, and
-	if Path denotes a path, creates a list of atoms which
-	consist of the Path prepended to each of the file names.
- *!-------------------------------------------------------*/
-
+/*!---------------------------------------------------------------------
+ |      pathPlusFilesList/3.
+ |      pathPlusFilesList(SourceFilesList, Path, ExtendedFilesList)
+ |      pathPlusFilesList(+, +, -)
+ |
+ |      - attaches a path to each of a list of file names
+ |
+ |      If SourceFilesList is list of items denoting file names, and
+ |      if Path denotes a path, creates a list of atoms which consists
+ |      of the Path prepended to each of the file names.  Functionally
+ |      identical to prefix_dir/3 in library file miscatom.pro.
+ |
+ | Examples
+ |      ?- pathPlusFilesList(['foo.pro','bar.pro','zip.pro'], 'mom/kids', EFL).
+ |      EFL=['mom/kids/foo.pro','mom/kids/bar.pro','mom/kids/zip.pro']
+ *!--------------------------------------------------------------------*/
 pathPlusFilesList([], _, []).
 pathPlusFilesList([File | SourceFilesList], Path, 
 					[XFile | ExtendedFilesList]) :-

--- a/core/alsp_src/builtins/filepath.pro
+++ b/core/alsp_src/builtins/filepath.pro
@@ -49,6 +49,31 @@ export join_path/2.
 export directory_self/1.
 export parent_path/1.
 
+/*!---------------------------------------------------------------------
+ |      file_extension/3
+ |      file_extension(FullName, Name, Ext)
+ |      file_extension(+/-, +/-, +/-)
+ |
+ |      - Access or add the extension for a filename.
+ |
+ |      If FullName is instantiated, decomposes it to yield the
+ |      underlying Filename (unified with Name)  and extension (unified
+ |      with Ext.  If FullName is instantiated but has no extension, then
+ |      Name is unified with FullName and Ext is unified with ''.
+ |      If FullName is uninstantiated and both Name, Ext are instantiated,
+ |      composes the filename plus extension out of Name, Ext and unifies
+ |      that with FullName.
+ |
+ | Examples
+ |      ?- file_extension(foo, Name1, Ext1).
+ |      Name1=foo
+ |      Ext1=''
+ |      ?- file_extension('foo.pro', Name2, Ext2).
+ |      Name2=foo
+ |      Ext2=pro
+ |      ?- file_extension(FullName, bar, pro).
+ |      FullName='bar.pro'
+ *!--------------------------------------------------------------------*/
 file_extension(FullName, Name, Ext) :-
 	nonvar(FullName),
 	!,


### PR DESCRIPTION
- Remove the exports for internal, OS-specific procedures to reduce surface area.
- Reorganize exports & code to group similar procedures together.
- Add in-code doc for future processing by doctool doc generator.