### PR TITLE
Remove never-implemented file_size/2

### DIFF
--- a/core/alsp_src/builtins/blt_msg.pro
+++ b/core/alsp_src/builtins/blt_msg.pro
@@ -487,8 +487,6 @@ warning_code(lib_act,		'Error activating library: %t %t %t-%t\n').
 warning_code(lib_pth,		'Non-existent library path: %t\n').
 warning_code(loc_alslib, 	'Can\'t locate ALS library in ALSDIR: %t\n').
 
-warning_code(nyi, 			'%t not yet implemented on %t.\n').
-
 
 info_code(start_consult,	'Consulting %t ... ').
 info_code(end_consult,	'done.\n').

--- a/core/alsp_src/builtins/fsdos.pro
+++ b/core/alsp_src/builtins/fsdos.pro
@@ -251,21 +251,6 @@ fileTypeToAttr(volid,      8).
 fileTypeToAttr(directory, 16).
 fileTypeToAttr(archive,   32).
 
-/*!----------------------------------------------------------------
- |	file_size/2
- |	file_size(FileName,Size)
- |	file_size(+,-)
- |
- |	- returns the size of a file
- |
- |	If File is an atom (possibly quoted) which is the name of a
- |	file in the current working directory, Size is the size of
- |	that file in bytes.
- *!----------------------------------------------------------------*/
-file_size(_,0)
-	:-
-	prolog_system_error(nyi, ['file_size/2',dos_djgpp]).
-
 /*---------------------------------------------------------------------
  |	Determine current disk drive. Drive = constant (1=A, 2=B, etc).
  *---------------------------------------------------------------------*/

--- a/core/alsp_src/builtins/fsmac.pro
+++ b/core/alsp_src/builtins/fsmac.pro
@@ -315,21 +315,6 @@ make_reg_exp([C | RestPattern],[C | RestRegex])
 	:-
 	make_reg_exp(RestPattern,RestRegex).
 
-/*!----------------------------------------------------------------
- |	file_size/2
- |	file_size(FileName,Size)
- |	file_size(+,-)
- |
- |	- returns the size of a file
- |
- |	If File is an atom (possibly quoted) which is the name of a
- |	file in the current working directory, Size is the size of
- |	that file in bytes.
- *!----------------------------------------------------------------*/
-file_size(_,0)
-	:-
-	prolog_system_error(nyi, ['file_size/2',unix]).
-
 %--------------------------------------------------------------------
 %	get_current_drive/1
 %--------------------------------------------------------------------

--- a/core/alsp_src/builtins/fsunix.pro
+++ b/core/alsp_src/builtins/fsunix.pro
@@ -408,21 +408,6 @@ make_reg_exp([C | RestPattern],[C | RestRegex])
 	:-
 	make_reg_exp(RestPattern,RestRegex).
 
-/*!----------------------------------------------------------------
- |	file_size/2
- |	file_size(FileName,Size)
- |	file_size(+,-)
- |
- |	- returns the size of a file
- |
- |	If File is an atom (possibly quoted) which is the name of a
- |	file in the current working directory, Size is the size of
- |	that file in bytes.
- *!----------------------------------------------------------------*/
-file_size(_,0)
-	:-
-	prolog_system_error(nyi, ['file_size/2',unix]).
-
 /*
  *	The following are essentially no-ops on unix, but
  *	need to do something for portability.  In accordance 

--- a/core/alsp_src/builtins/fswin32.pro
+++ b/core/alsp_src/builtins/fswin32.pro
@@ -316,21 +316,6 @@ make_reg_exp([C | RestPattern],[C | RestRegex])
 	:-
 	make_reg_exp(RestPattern,RestRegex).
 
-/*!----------------------------------------------------------------
- |	file_size/2
- |	file_size(FileName,Size)
- |	file_size(+,-)
- |
- |	- returns the size of a file
- |
- |	If File is an atom (possibly quoted) which is the name of a
- |	file in the current working directory, Size is the size of
- |	that file in bytes.
- *!----------------------------------------------------------------*/
-file_size(_,0)
-	:-
-	prolog_system_error(nyi, ['file_size/2',unix]).
-
 %--------------------------------------------------------------------
 %	get_current_drive/1
 %--------------------------------------------------------------------


### PR DESCRIPTION
This predicate has been marked NYI for 30+ years, and file_status/2 can provide the
same information.