### PR TITLE
Printf191 - Fixes printf([]) succeeds without no output.

### DIFF
--- a/core/alsp_src/builtins/blt_io.pro
+++ b/core/alsp_src/builtins/blt_io.pro
@@ -75,8 +75,8 @@ printf_check_format(Var, _) :-
 	var(Var),
 	!,
 	instantiation_error(2).
-printf_check_format([], []) :-
-	!.
+printf_check_format([], List) :-
+        atom_codes([], List).
 printf_check_format(Atom, List) :-
 	atom(Atom),
 	!,

--- a/core/alsp_src/builtins/blt_io.pro
+++ b/core/alsp_src/builtins/blt_io.pro
@@ -75,8 +75,6 @@ printf_check_format(Var, _) :-
 	var(Var),
 	!,
 	instantiation_error(2).
-printf_check_format([], List) :-
-        atom_codes([], List).
 printf_check_format(Atom, List) :-
 	atom(Atom),
 	!,


### PR DESCRIPTION
Fixes #191.  Fixes printf([]) succeeds without no output by dropping the special case for printf_check_format([], []).