### PR TITLE
Added explicit check for PHP, and document requirement on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ CentOS/Fedora: `sudo yum groupinstall 'Development Tools' && sudo yum install ru
 
 ### Mac OS X
 
-[Xcode](https://developer.apple.com/xcode/) command line tools. For version before High Sierra (10.13), a recent version of Ruby is required. [Homebrew Ruby](https://jekyllrb.com/docs/installation/macos/#homebrew) is recommended.
+[Xcode](https://developer.apple.com/xcode/) command line tools.
+For version before High Sierra (10.13), a recent version of Ruby is required. [Homebrew Ruby](https://jekyllrb.com/docs/installation/macos/#homebrew) is recommended.
+For versions after Big Sur (11), PHP is required for testing. [Homebrew PHP](https://formulae.brew.sh/formula/php) is recommended.
 
 ### Windows
 

--- a/core/alsp_src/tests/tsuite/curl_test.sh
+++ b/core/alsp_src/tests/tsuite/curl_test.sh
@@ -4,6 +4,8 @@ set -eux
 
 : ${debug:=0}
 
+which ${PHP:-php} || (echo 'Error: PHP required for Curl Tests' 1>&2 ; exit 1)
+
 ALSPRO=$1
 
 TSUITE=$(dirname "$0")


### PR DESCRIPTION
You can test the new error message by using the PHP env variable with a non-sense value:

```
% PHP=foobar make curl_test
...
Error: PHP required for Curl Tests
+ exit 1
make: *** [curl_test] Error 1
```