### PR TITLE
Added explicit check for PHP, and documented requirement on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ CentOS/Fedora: `sudo yum groupinstall 'Development Tools' && sudo yum install ru
 
 ### Mac OS X
 
-[Xcode](https://developer.apple.com/xcode/) command line tools. For version before High Sierra (10.13), a recent version of Ruby is required. [Homebrew Ruby](https://jekyllrb.com/docs/installation/macos/#homebrew) is recommended.
+[Xcode](https://developer.apple.com/xcode/) command line tools.
+For version before High Sierra (10.13), a recent version of Ruby is required. [Homebrew Ruby](https://jekyllrb.com/docs/installation/macos/#homebrew) is recommended.
+For versions after Big Sur (11), PHP is required for testing. [Homebrew PHP](https://formulae.brew.sh/formula/php) is recommended.
 
 ### Windows
 

--- a/core/alsp_src/tests/tsuite/curl_test.sh
+++ b/core/alsp_src/tests/tsuite/curl_test.sh
@@ -10,6 +10,8 @@ set -eux
 
 : ${debug:=0}
 
+which ${PHP:-php} || (echo 'Error: PHP required for Curl Tests' 1>&2 ; exit 1)
+
 ALSPRO=$1
 
 TSUITE=$(dirname "$0")


### PR DESCRIPTION
New pull request to revive PR #201. Fixes #200

This PR is a rebased of the branch off latest master, so if you checkout the branch in a fresh clone, you should see the PHP-required error message. I.e.:

```
% make curl_test
...
Error: PHP required for Curl Tests
+ exit 1
make: *** [curl_test] Error 1
```

Then try following new instructions for PHP on Mac in the branch's README.md, and the PHP-required error should go away.

If that all works ok, then please merge pull request.